### PR TITLE
Add BaseBoolInt

### DIFF
--- a/api/account.go
+++ b/api/account.go
@@ -118,7 +118,7 @@ func (vk *VK) AccountRegisterDevice(params Params) (response int, err error) {
 
 // AccountSaveProfileInfoResponse struct
 type AccountSaveProfileInfoResponse struct {
-	Changed     int                       `json:"changed"`
+	Changed     object.BaseBoolInt        `json:"changed"`
 	NameRequest object.AccountNameRequest `json:"name_request"`
 }
 

--- a/api/board.go
+++ b/api/board.go
@@ -115,7 +115,7 @@ type BoardGetTopicsResponse struct {
 	Count        int                 `json:"count"`
 	Items        []object.BoardTopic `json:"items"`
 	DefaultOrder float64             `json:"default_order"` // BUG(VK): default_order int https://vk.com/bug136682
-	CanAddTopics int                 `json:"can_add_topics"`
+	CanAddTopics object.BaseBoolInt  `json:"can_add_topics"`
 }
 
 // BoardGetTopics returns a list of topics on a community's discussion board.
@@ -135,7 +135,7 @@ type BoardGetTopicsExtendedResponse struct {
 	Count        int                  `json:"count"`
 	Items        []object.BoardTopic  `json:"items"`
 	DefaultOrder float64              `json:"default_order"` // BUG(VK): default_order int https://vk.com/bug136682
-	CanAddTopics int                  `json:"can_add_topics"`
+	CanAddTopics object.BaseBoolInt   `json:"can_add_topics"`
 	Profiles     []object.UsersUser   `json:"profiles"`
 	Groups       []object.GroupsGroup `json:"groups"`
 }

--- a/api/friends.go
+++ b/api/friends.go
@@ -38,11 +38,11 @@ func (vk *VK) FriendsAreFriends(params Params) (response FriendsAreFriendsRespon
 
 // FriendsDeleteResponse struct
 type FriendsDeleteResponse struct {
-	Success           int `json:"success"`
-	FriendDeleted     int `json:"friend_deleted"`
-	OutRequestDeleted int `json:"out_request_deleted"`
-	InRequestDeleted  int `json:"in_request_deleted"`
-	SuggestionDeleted int `json:"suggestion_deleted"`
+	Success           object.BaseBoolInt `json:"success"`
+	FriendDeleted     object.BaseBoolInt `json:"friend_deleted"`
+	OutRequestDeleted object.BaseBoolInt `json:"out_request_deleted"`
+	InRequestDeleted  object.BaseBoolInt `json:"in_request_deleted"`
+	SuggestionDeleted object.BaseBoolInt `json:"suggestion_deleted"`
 }
 
 // FriendsDelete declines a friend request or deletes a user from the current user's friend list.

--- a/api/groups.go
+++ b/api/groups.go
@@ -279,7 +279,7 @@ func (vk *VK) GroupsGetCatalog(params Params) (response GroupsGetCatalogResponse
 
 // GroupsGetCatalogInfoResponse struct
 type GroupsGetCatalogInfoResponse struct {
-	Enabled    int                          `json:"enabled"`
+	Enabled    object.BaseBoolInt           `json:"enabled"`
 	Categories []object.GroupsGroupCategory `json:"categories"`
 }
 
@@ -297,7 +297,7 @@ func (vk *VK) GroupsGetCatalogInfo(params Params) (response GroupsGetCatalogInfo
 
 // GroupsGetCatalogInfoExtendedResponse struct
 type GroupsGetCatalogInfoExtendedResponse struct {
-	Enabled    int                              `json:"enabled"`
+	Enabled    object.BaseBoolInt               `json:"enabled"`
 	Categories []object.GroupsGroupCategoryFull `json:"categories"`
 }
 
@@ -520,11 +520,11 @@ func (vk *VK) GroupsIsMember(params Params) (response int, err error) {
 
 // GroupsIsMemberExtendedResponse struct
 type GroupsIsMemberExtendedResponse struct {
-	Invitation int `json:"invitation"` // Information whether user has been invited to the group
-	Member     int `json:"member"`     // Information whether user is a member of the group
-	Request    int `json:"request"`    // Information whether user has send request to the group
-	CanInvite  int `json:"can_invite"` // Information whether user can be invite
-	CanRecall  int `json:"can_recall"` // Information whether user's invite to the group can be recalled
+	Invitation object.BaseBoolInt `json:"invitation"` // Information whether user has been invited to the group
+	Member     object.BaseBoolInt `json:"member"`     // Information whether user is a member of the group
+	Request    object.BaseBoolInt `json:"request"`    // Information whether user has send request to the group
+	CanInvite  object.BaseBoolInt `json:"can_invite"` // Information whether user can be invite
+	CanRecall  object.BaseBoolInt `json:"can_recall"` // Information whether user's invite to the group can be recalled
 }
 
 // GroupsIsMemberExtended returns information specifying whether a user is a member of a community.

--- a/api/leads.go
+++ b/api/leads.go
@@ -50,8 +50,8 @@ func (vk *VK) LeadsGetUsers(params Params) (response LeadsGetUsersResponse, err 
 
 // LeadsMetricHitResponse struct
 type LeadsMetricHitResponse struct {
-	Result       bool   `json:"result"`        // Information whether request has been processed successfully
-	RedirectLink string `json:"redirect_link"` // Redirect link
+	Result       object.BaseBoolInt `json:"result"`        // Information whether request has been processed successfully
+	RedirectLink string             `json:"redirect_link"` // Redirect link
 }
 
 // LeadsMetricHit Counts the metric event.

--- a/api/likes.go
+++ b/api/likes.go
@@ -68,8 +68,8 @@ func (vk *VK) LikesGetListExtended(params Params) (response LikesGetListExtended
 
 // LikesIsLikedResponse struct
 type LikesIsLikedResponse struct {
-	Liked  int `json:"liked"`
-	Copied int `json:"copied"`
+	Liked  object.BaseBoolInt `json:"liked"`
+	Copied object.BaseBoolInt `json:"copied"`
 }
 
 // LikesIsLiked checks for the object in the Likes list of the specified user.

--- a/api/messages.go
+++ b/api/messages.go
@@ -181,19 +181,19 @@ func (vk *VK) MessagesGetChatPreview(params Params) (response MessagesGetChatPre
 // MessagesGetConversationMembersResponse struct
 type MessagesGetConversationMembersResponse struct {
 	Items []struct {
-		MemberID  int  `json:"member_id"`
-		JoinDate  int  `json:"join_date"`
-		InvitedBy int  `json:"invited_by"`
-		IsOwner   bool `json:"is_owner,omitempty"`
-		IsAdmin   bool `json:"is_admin,omitempty"`
-		CanKick   bool `json:"can_kick,omitempty"`
+		MemberID  int                `json:"member_id"`
+		JoinDate  int                `json:"join_date"`
+		InvitedBy int                `json:"invited_by"`
+		IsOwner   object.BaseBoolInt `json:"is_owner,omitempty"`
+		IsAdmin   object.BaseBoolInt `json:"is_admin,omitempty"`
+		CanKick   object.BaseBoolInt `json:"can_kick,omitempty"`
 	} `json:"items"`
 	Count            int `json:"count"`
 	ChatRestrictions struct {
-		OnlyAdminsInvite   bool `json:"only_admins_invite"`
-		OnlyAdminsEditPin  bool `json:"only_admins_edit_pin"`
-		OnlyAdminsEditInfo bool `json:"only_admins_edit_info"`
-		AdminsPromoteUsers bool `json:"admins_promote_users"`
+		OnlyAdminsInvite   object.BaseBoolInt `json:"only_admins_invite"`
+		OnlyAdminsEditPin  object.BaseBoolInt `json:"only_admins_edit_pin"`
+		OnlyAdminsEditInfo object.BaseBoolInt `json:"only_admins_edit_info"`
+		AdminsPromoteUsers object.BaseBoolInt `json:"admins_promote_users"`
 	} `json:"chat_restrictions"`
 	object.ExtendedResponse
 }
@@ -345,7 +345,7 @@ type MessagesGetLongPollHistoryResponse struct {
 	Profiles []object.UsersUser `json:"profiles"`
 	// Chats struct {} `json:"chats"`
 	NewPTS        int                           `json:"new_pts"`
-	More          bool                          `json:"chats"`
+	More          object.BaseBoolInt            `json:"chats"`
 	Conversations []object.MessagesConversation `json:"conversations"`
 }
 
@@ -370,7 +370,7 @@ func (vk *VK) MessagesGetLongPollServer(params Params) (response MessagesGetLong
 
 // MessagesIsMessagesFromGroupAllowedResponse struct
 type MessagesIsMessagesFromGroupAllowedResponse struct {
-	IsAllowed int `json:"is_allowed"`
+	IsAllowed object.BaseBoolInt `json:"is_allowed"`
 }
 
 // MessagesIsMessagesFromGroupAllowed returns information whether

--- a/api/newsfeed.go
+++ b/api/newsfeed.go
@@ -153,8 +153,6 @@ type NewsfeedGetSuggestedSourcesResponse struct {
 
 // NewsfeedGetSuggestedSources returns communities and users that current user is suggested to follow.
 //
-// BUG: group.is_closed int | user.is_closed bool
-//
 // https://vk.com/dev/newsfeed.getSuggestedSources
 func (vk *VK) NewsfeedGetSuggestedSources(params Params) (response NewsfeedGetSuggestedSourcesResponse, err error) {
 	err = vk.RequestUnmarshal("newsfeed.getSuggestedSources", params, &response)

--- a/api/notifications.go
+++ b/api/notifications.go
@@ -37,8 +37,8 @@ func (vk *VK) NotificationsMarkAsViewed(params Params) (response int, err error)
 
 // NotificationsSendMessageResponse struct
 type NotificationsSendMessageResponse []struct {
-	UserID int  `json:"user_id"`
-	Status bool `json:"status"`
+	UserID int                `json:"user_id"`
+	Status object.BaseBoolInt `json:"status"`
 	Error  struct {
 		Code        int    `json:"code"`
 		Description string `json:"description"`

--- a/api/notifications_test.go
+++ b/api/notifications_test.go
@@ -17,7 +17,7 @@ func TestVK_NotificationsGet(t *testing.T) {
 	noError(t, err)
 	// assert.NotEmpty(t, res.Count)
 	// assert.NotEmpty(t, res.Items)
-	assert.NotEmpty(t, res.LastViewed)
+	// assert.NotEmpty(t, res.LastViewed)
 	assert.NotEmpty(t, res.TTL)
 }
 

--- a/api/photos.go
+++ b/api/photos.go
@@ -149,7 +149,7 @@ func (vk *VK) PhotosGetAlbumsCount(params Params) (response int, err error) {
 type PhotosGetAllResponse struct {
 	Count int                               `json:"count"` // Total number
 	Items []object.PhotosPhotoXtrRealOffset `json:"items"`
-	More  int                               `json:"more"` // Information whether next page is presented
+	More  object.BaseBoolInt                `json:"more"` // Information whether next page is presented
 }
 
 // PhotosGetAll returns a list of photos belonging to a user or community, in reverse chronological order.
@@ -168,7 +168,7 @@ func (vk *VK) PhotosGetAll(params Params) (response PhotosGetAllResponse, err er
 type PhotosGetAllExtendedResponse struct {
 	Count int                                   `json:"count"` // Total number
 	Items []object.PhotosPhotoFullXtrRealOffset `json:"items"`
-	More  int                                   `json:"more"` // Information whether next page is presented
+	More  object.BaseBoolInt                    `json:"more"` // Information whether next page is presented
 }
 
 // PhotosGetAllExtended returns a list of photos belonging to a user or community, in reverse chronological order.

--- a/api/wall.go
+++ b/api/wall.go
@@ -144,9 +144,9 @@ func (vk *VK) WallGetByIDExtended(params Params) (response WallGetByIDExtendedRe
 // WallGetCommentResponse struct
 type WallGetCommentResponse struct {
 	Items             []object.WallWallComment `json:"items"`
-	CanPost           bool                     `json:"can_post"`
-	ShowReplyButton   bool                     `json:"show_reply_button"`
-	GroupsCanPost     bool                     `json:"groups_can_post"`
+	CanPost           object.BaseBoolInt       `json:"can_post"`
+	ShowReplyButton   object.BaseBoolInt       `json:"show_reply_button"`
+	GroupsCanPost     object.BaseBoolInt       `json:"groups_can_post"`
 	CurrentLevelCount int                      `json:"current_level_count"`
 }
 
@@ -166,9 +166,9 @@ func (vk *VK) WallGetComment(params Params) (response WallGetCommentResponse, er
 type WallGetCommentExtendedResponse struct {
 	Count             int                      `json:"count"`
 	Items             []object.WallWallComment `json:"items"`
-	CanPost           bool                     `json:"can_post"`
-	ShowReplyButton   bool                     `json:"show_reply_button"`
-	GroupsCanPost     bool                     `json:"groups_can_post"`
+	CanPost           object.BaseBoolInt       `json:"can_post"`
+	ShowReplyButton   object.BaseBoolInt       `json:"show_reply_button"`
+	GroupsCanPost     object.BaseBoolInt       `json:"groups_can_post"`
 	CurrentLevelCount int                      `json:"current_level_count"`
 	Profiles          []object.UsersUser       `json:"profiles"`
 	Groups            []object.GroupsGroup     `json:"groups"`
@@ -188,9 +188,9 @@ func (vk *VK) WallGetCommentExtended(params Params) (response WallGetCommentExte
 
 // WallGetCommentsResponse struct
 type WallGetCommentsResponse struct {
-	CanPost           bool                     `json:"can_post"`
-	ShowReplyButton   bool                     `json:"show_reply_button"`
-	GroupsCanPost     bool                     `json:"groups_can_post"`
+	CanPost           object.BaseBoolInt       `json:"can_post"`
+	ShowReplyButton   object.BaseBoolInt       `json:"show_reply_button"`
+	GroupsCanPost     object.BaseBoolInt       `json:"groups_can_post"`
 	CurrentLevelCount int                      `json:"current_level_count"`
 	Count             int                      `json:"count"`
 	Items             []object.WallWallComment `json:"items"`
@@ -210,9 +210,9 @@ func (vk *VK) WallGetComments(params Params) (response WallGetCommentsResponse, 
 
 // WallGetCommentsExtendedResponse struct
 type WallGetCommentsExtendedResponse struct {
-	CanPost           bool                     `json:"can_post"`
-	ShowReplyButton   bool                     `json:"show_reply_button"`
-	GroupsCanPost     bool                     `json:"groups_can_post"`
+	CanPost           object.BaseBoolInt       `json:"can_post"`
+	ShowReplyButton   object.BaseBoolInt       `json:"show_reply_button"`
+	GroupsCanPost     object.BaseBoolInt       `json:"groups_can_post"`
 	CurrentLevelCount int                      `json:"current_level_count"`
 	Count             int                      `json:"count"`
 	Items             []object.WallWallComment `json:"items"`

--- a/object/account.go
+++ b/object/account.go
@@ -77,19 +77,19 @@ type AccountAccountCounters struct {
 
 // AccountInfo struct
 type AccountInfo struct {
-	Country           string `json:"country"`           // Country code
-	HTTPSRequired     int    `json:"https_required"`    // Information whether HTTPS-only is enabled
-	Intro             int    `json:"intro"`             // Information whether user has been processed intro
-	Lang              int    `json:"lang"`              // Language ID
-	NoWallReplies     int    `json:"no_wall_replies"`   // Information whether wall comments should be hidden
-	OwnPostsDefault   int    `json:"own_posts_default"` // Information whether only owners posts should be shown
-	TwoFactorRequired int    `json:"2fa_required"`      // Two factor authentication is enabled
+	Country           string      `json:"country"`           // Country code
+	Lang              int         `json:"lang"`              // Language ID
+	HTTPSRequired     BaseBoolInt `json:"https_required"`    // Information whether HTTPS-only is enabled
+	Intro             BaseBoolInt `json:"intro"`             // Information whether user has been processed intro
+	NoWallReplies     BaseBoolInt `json:"no_wall_replies"`   // Information whether wall comments should be hidden
+	OwnPostsDefault   BaseBoolInt `json:"own_posts_default"` // Information whether only owners posts should be shown
+	TwoFactorRequired BaseBoolInt `json:"2fa_required"`      // Two factor authentication is enabled
 }
 
 // AccountPushSettings struct
 type AccountPushSettings struct {
 	Conversations AccountPushConversations `json:"conversations"`
-	Disabled      int                      `json:"disabled"`       // Information whether notifications are disabled
+	Disabled      BaseBoolInt              `json:"disabled"`       // Information whether notifications are disabled
 	DisabledUntil int                      `json:"disabled_until"` // Time until that notifications are disabled in Unixtime
 	Settings      AccountPushParams        `json:"settings"`
 }
@@ -108,7 +108,7 @@ type AccountUserSettings struct {
 	Phone            string             `json:"phone"`    // User phone number with some hidden digits
 	Relation         int                `json:"relation"` // User relationship status
 	RelationPartner  UsersUserMin       `json:"relation_partner"`
-	RelationPending  int                `json:"relation_pending"` // Information whether relation status is pending
+	RelationPending  BaseBoolInt        `json:"relation_pending"` // Information whether relation status is pending
 	RelationRequests []UsersUserMin     `json:"relation_requests"`
 	ScreenName       string             `json:"screen_name"` // Domain name of the user's page
 	Sex              int                `json:"sex"`         // User sex

--- a/object/ads.go
+++ b/object/ads.go
@@ -8,26 +8,26 @@ type AdsAccesses struct {
 
 // AdsAccount struct
 type AdsAccount struct {
-	AccessRole    string `json:"access_role"`
-	AccountID     int    `json:"account_id"`     // Account ID
-	AccountStatus int    `json:"account_status"` // Information whether account is active
-	AccountType   string `json:"account_type"`
+	AccessRole    string      `json:"access_role"`
+	AccountID     int         `json:"account_id"`     // Account ID
+	AccountStatus BaseBoolInt `json:"account_status"` // Information whether account is active
+	AccountType   string      `json:"account_type"`
 }
 
 // AdsAdLayout struct
 type AdsAdLayout struct {
-	AdFormat    int    `json:"ad_format"`   // Ad format
-	CampaignID  int    `json:"campaign_id"` // Campaign ID
-	CostType    int    `json:"cost_type"`
-	Description string `json:"description"`  // Ad description
-	ID          int    `json:"id"`           // Ad ID
-	ImageSrc    string `json:"image_src"`    // Image URL
-	ImageSrc2x  string `json:"image_src_2x"` // URL of the preview image in double size
-	LinkDomain  string `json:"link_domain"`  // Domain of advertised object
-	LinkURL     string `json:"link_url"`     // URL of advertised object
-	PreviewLink string `json:"preview_link"` // TODO: check it link to preview an ad as it is shown on the website
-	Title       string `json:"title"`        // Ad title
-	Video       int    `json:"video"`        // Information whether the ad is a video
+	AdFormat    int         `json:"ad_format"`   // Ad format
+	CampaignID  int         `json:"campaign_id"` // Campaign ID
+	CostType    int         `json:"cost_type"`
+	Description string      `json:"description"`  // Ad description
+	ID          int         `json:"id"`           // Ad ID
+	ImageSrc    string      `json:"image_src"`    // Image URL
+	ImageSrc2x  string      `json:"image_src_2x"` // URL of the preview image in double size
+	LinkDomain  string      `json:"link_domain"`  // Domain of advertised object
+	LinkURL     string      `json:"link_url"`     // URL of advertised object
+	PreviewLink string      `json:"preview_link"` // TODO: check it link to preview an ad as it is shown on the website
+	Title       string      `json:"title"`        // Ad title
+	Video       BaseBoolInt `json:"video"`        // Information whether the ad is a video
 }
 
 // AdsCampaign struct
@@ -59,36 +59,36 @@ type AdsClient struct {
 
 // AdsCriteria struct
 type AdsCriteria struct {
-	AgeFrom              int    `json:"age_from"`               // Age from
-	AgeTo                int    `json:"age_to"`                 // Age to
-	Apps                 string `json:"apps"`                   // Apps IDs
-	AppsNot              string `json:"apps_not"`               // Apps IDs to except
-	Birthday             int    `json:"birthday"`               // Days to birthday
-	Cities               string `json:"cities"`                 // Cities IDs
-	CitiesNot            string `json:"cities_not"`             // Cities IDs to except
-	Country              int    `json:"country"`                // Country ID
-	Districts            string `json:"districts"`              // Districts IDs
-	Groups               string `json:"groups"`                 // Communities IDs
-	InterestCategories   string `json:"interest_categories"`    // Interests categories IDs
-	Interests            string `json:"interests"`              // Interests
-	Paying               int    `json:"paying"`                 // Information whether the user has proceeded VK payments before
-	Positions            string `json:"positions"`              // Positions IDs
-	Religions            string `json:"religions"`              // Religions IDs
-	RetargetingGroups    string `json:"retargeting_groups"`     // Retargeting groups IDs
-	RetargetingGroupsNot string `json:"retargeting_groups_not"` // Retargeting groups IDs to except
-	SchoolFrom           int    `json:"school_from"`            // School graduation year from
-	SchoolTo             int    `json:"school_to"`              // School graduation year to
-	Schools              string `json:"schools"`                // Schools IDs
-	Sex                  int    `json:"sex"`
-	Stations             string `json:"stations"`      // Stations IDs
-	Statuses             string `json:"statuses"`      // Relationship statuses
-	Streets              string `json:"streets"`       // Streets IDs
-	Travellers           int    `json:"travellers"`    // Travellers only
-	UniFrom              int    `json:"uni_from"`      // University graduation year from
-	UniTo                int    `json:"uni_to"`        // University graduation year to
-	UserBrowsers         string `json:"user_browsers"` // Browsers
-	UserDevices          string `json:"user_devices"`  // Devices
-	UserOs               string `json:"user_os"`       // Operating systems
+	AgeFrom              int         `json:"age_from"`               // Age from
+	AgeTo                int         `json:"age_to"`                 // Age to
+	Apps                 string      `json:"apps"`                   // Apps IDs
+	AppsNot              string      `json:"apps_not"`               // Apps IDs to except
+	Birthday             int         `json:"birthday"`               // Days to birthday
+	Cities               string      `json:"cities"`                 // Cities IDs
+	CitiesNot            string      `json:"cities_not"`             // Cities IDs to except
+	Country              int         `json:"country"`                // Country ID
+	Districts            string      `json:"districts"`              // Districts IDs
+	Groups               string      `json:"groups"`                 // Communities IDs
+	InterestCategories   string      `json:"interest_categories"`    // Interests categories IDs
+	Interests            string      `json:"interests"`              // Interests
+	Paying               BaseBoolInt `json:"paying"`                 // Information whether the user has proceeded VK payments before
+	Positions            string      `json:"positions"`              // Positions IDs
+	Religions            string      `json:"religions"`              // Religions IDs
+	RetargetingGroups    string      `json:"retargeting_groups"`     // Retargeting groups IDs
+	RetargetingGroupsNot string      `json:"retargeting_groups_not"` // Retargeting groups IDs to except
+	SchoolFrom           int         `json:"school_from"`            // School graduation year from
+	SchoolTo             int         `json:"school_to"`              // School graduation year to
+	Schools              string      `json:"schools"`                // Schools IDs
+	Sex                  int         `json:"sex"`
+	Stations             string      `json:"stations"`      // Stations IDs
+	Statuses             string      `json:"statuses"`      // Relationship statuses
+	Streets              string      `json:"streets"`       // Streets IDs
+	Travellers           int         `json:"travellers"`    // Travellers only
+	UniFrom              int         `json:"uni_from"`      // University graduation year from
+	UniTo                int         `json:"uni_to"`        // University graduation year to
+	UserBrowsers         string      `json:"user_browsers"` // Browsers
+	UserDevices          string      `json:"user_devices"`  // Devices
+	UserOs               string      `json:"user_os"`       // Operating systems
 }
 
 // AdsDemoStats struct
@@ -259,15 +259,15 @@ type AdsAd struct {
 	CostType              int         `json:"cost_type"`
 	Cpc                   int         `json:"cpc"`                    // Cost of a click, kopecks
 	Cpm                   int         `json:"cpm"`                    // Cost of 1000 impressions, kopecks
-	DisclaimerMedical     int         `json:"disclaimer_medical"`     // Information whether disclaimer is enabled
-	DisclaimerSpecialist  int         `json:"disclaimer_specialist"`  // Information whether disclaimer is enabled
-	DisclaimerSupplements int         `json:"disclaimer_supplements"` // Information whether disclaimer is enabled
-	ID                    int         `json:"id"`                     // Ad ID
+	DisclaimerMedical     BaseBoolInt `json:"disclaimer_medical"`     // Information whether disclaimer is enabled
+	DisclaimerSpecialist  BaseBoolInt `json:"disclaimer_specialist"`  // Information whether disclaimer is enabled
+	DisclaimerSupplements BaseBoolInt `json:"disclaimer_supplements"` // Information whether disclaimer is enabled
+	Video                 BaseBoolInt `json:"video"`                  // Information whether the ad is a video
+	ImpressionsLimited    BaseBoolInt `json:"impressions_limited"`    // Information whether impressions are limited
 	ImpressionsLimit      int         `json:"impressions_limit"`      // Impressions limit
-	ImpressionsLimited    int         `json:"impressions_limited"`    // Information whether impressions are limited
+	ID                    int         `json:"id"`                     // Ad ID
 	Name                  string      `json:"name"`                   // Ad title
 	Status                int         `json:"status"`
-	Video                 int         `json:"video"` // Information whether the ad is a video
 }
 
 // AdsPromotedPostReach struct

--- a/object/apps.go
+++ b/object/apps.go
@@ -2,25 +2,25 @@ package object // import "github.com/SevereCloud/vksdk/object"
 
 // AppsApp struct
 type AppsApp struct {
-	AuthorGroup     int    `json:"author_group"`     // Official community's ID
-	AuthorID        int    `json:"author_id"`        // Application author's ID
-	AuthorURL       string `json:"author_url"`       // Application author's URL
-	Banner1120      string `json:"banner_1120"`      // URL of the app banner with 1120 px in width
-	Banner560       string `json:"banner_560"`       // URL of the app banner with 560 px in width
-	CatalogPosition int    `json:"catalog_position"` // Catalog position
-	Description     string `json:"description"`      // Application description
-	Friends         []int  `json:"friends"`
-	Genre           string `json:"genre"`         // Genre name
-	GenreID         int    `json:"genre_id"`      // Genre ID
-	Icon139         string `json:"icon_139"`      // URL of the app icon with 139 px in width
-	Icon150         string `json:"icon_150"`      // URL of the app icon with 150 px in width
-	Icon278         string `json:"icon_278"`      // URL of the app icon with 279 px in width
-	Icon75          string `json:"icon_75"`       // URL of the app icon with 75 px in width
-	ID              int    `json:"id"`            // Application ID
-	International   int    `json:"international"` // Information whether the application is multilanguage
-	IsInCatalog     int    `json:"is_in_catalog"` // Information whether application is in mobile catalog
-	// BUG(VK): https://github.com/SevereCloud/vksdk/issues/63
-	// Installed       bool          `json:"installed"`
+	AuthorGroup     int           `json:"author_group"`     // Official community's ID
+	AuthorID        int           `json:"author_id"`        // Application author's ID
+	AuthorURL       string        `json:"author_url"`       // Application author's URL
+	Banner1120      string        `json:"banner_1120"`      // URL of the app banner with 1120 px in width
+	Banner560       string        `json:"banner_560"`       // URL of the app banner with 560 px in width
+	CatalogPosition int           `json:"catalog_position"` // Catalog position
+	Description     string        `json:"description"`      // Application description
+	Friends         []int         `json:"friends"`
+	Genre           string        `json:"genre"`         // Genre name
+	GenreID         int           `json:"genre_id"`      // Genre ID
+	Icon139         string        `json:"icon_139"`      // URL of the app icon with 139 px in width
+	Icon150         string        `json:"icon_150"`      // URL of the app icon with 150 px in width
+	Icon278         string        `json:"icon_278"`      // URL of the app icon with 279 px in width
+	Icon75          string        `json:"icon_75"`       // URL of the app icon with 75 px in width
+	ID              int           `json:"id"`            // Application ID
+	International   BaseBoolInt   `json:"international"` // Information whether the application is multilanguage
+	IsInCatalog     BaseBoolInt   `json:"is_in_catalog"` // Information whether application is in mobile catalog
+	Installed       BaseBoolInt   `json:"installed"`
+	PushEnabled     BaseBoolInt   `json:"push_enabled"`
 	LeaderboardType int           `json:"leaderboard_type"`
 	MembersCount    int           `json:"members_count"`  // Members number
 	PlatformID      int           `json:"platform_id"`    // Application ID in store
@@ -31,7 +31,6 @@ type AppsApp struct {
 	Title           string        `json:"title"`   // Application title
 	Type            string        `json:"type"`
 	Icon16          string        `json:"icon_16"`
-	PushEnabled     int           `json:"push_enabled"`
 }
 
 // AppsLeaderboard struct

--- a/object/audio.go
+++ b/object/audio.go
@@ -13,8 +13,8 @@ type AudioAudioFull struct {
 	Duration    int                `json:"duration"`
 	Date        int                `json:"date"`
 	URL         string             `json:"url"`
-	IsHq        bool               `json:"is_hq"`
-	IsExplicit  bool               `json:"is_explicit"`
+	IsHq        BaseBoolInt        `json:"is_hq"`
+	IsExplicit  BaseBoolInt        `json:"is_explicit"`
 	LyricsID    int                `json:"lyrics_id"`
 	AlbumID     int                `json:"album_id"`
 	GenreID     int                `json:"genre_id"`
@@ -37,15 +37,15 @@ type AudioAudioArtist struct {
 
 // AudioAudio struct
 type AudioAudio struct {
-	AccessKey    string `json:"access_key"` // Access key for the audio
-	Artist       string `json:"artist"`     // Artist name
-	ID           int    `json:"id"`         // Audio ID
-	IsExplicit   bool   `json:"is_explicit"`
-	IsFocusTrack bool   `json:"is_focus_track"`
-	IsLicensed   bool   `json:"is_licensed"`
-	OwnerID      int    `json:"owner_id"` // Audio owner's ID
-	Title        string `json:"title"`    // Title
-	URL          string `json:"url"`      // URL of mp3 file
+	AccessKey    string      `json:"access_key"` // Access key for the audio
+	Artist       string      `json:"artist"`     // Artist name
+	ID           int         `json:"id"`         // Audio ID
+	IsExplicit   BaseBoolInt `json:"is_explicit"`
+	IsFocusTrack BaseBoolInt `json:"is_focus_track"`
+	IsLicensed   BaseBoolInt `json:"is_licensed"`
+	OwnerID      int         `json:"owner_id"` // Audio owner's ID
+	Title        string      `json:"title"`    // Title
+	URL          string      `json:"url"`      // URL of mp3 file
 }
 
 // ToAttachment return attachment format

--- a/object/board.go
+++ b/object/board.go
@@ -2,15 +2,15 @@ package object // import "github.com/SevereCloud/vksdk/object"
 
 // BoardTopic struct
 type BoardTopic struct {
-	Comments  int    `json:"comments"`   // Comments number
-	Created   int    `json:"created"`    // Date when the topic has been created in Unixtime
-	CreatedBy int    `json:"created_by"` // Creator ID
-	ID        int    `json:"id"`         // Topic ID
-	IsClosed  int    `json:"is_closed"`  // Information whether the topic is closed
-	IsFixed   int    `json:"is_fixed"`   // Information whether the topic is fixed
-	Title     string `json:"title"`      // Topic title
-	Updated   int    `json:"updated"`    // Date when the topic has been updated in Unixtime
-	UpdatedBy int    `json:"updated_by"` // ID of user who updated the topic
+	Comments  int         `json:"comments"`   // Comments number
+	Created   int         `json:"created"`    // Date when the topic has been created in Unixtime
+	CreatedBy int         `json:"created_by"` // Creator ID
+	ID        int         `json:"id"`         // Topic ID
+	IsClosed  BaseBoolInt `json:"is_closed"`  // Information whether the topic is closed
+	IsFixed   BaseBoolInt `json:"is_fixed"`   // Information whether the topic is fixed
+	Title     string      `json:"title"`      // Topic title
+	Updated   int         `json:"updated"`    // Date when the topic has been updated in Unixtime
+	UpdatedBy int         `json:"updated_by"` // ID of user who updated the topic
 }
 
 // BoardTopicComment struct
@@ -24,7 +24,7 @@ type BoardTopicComment struct {
 	// TopicID      int                     `json:"topic_id"`
 	// TopicOwnerID int                     `json:"topic_owner_id"`
 	Likes   BaseLikesInfo `json:"likes"`
-	CanEdit int           `json:"can_edit"` // Information whether current user can edit the comment
+	CanEdit BaseBoolInt   `json:"can_edit"` // Information whether current user can edit the comment
 }
 
 // BoardTopicPoll struct
@@ -32,7 +32,7 @@ type BoardTopicPoll struct {
 	AnswerID int           `json:"answer_id"` // Current user's answer ID
 	Answers  []PollsAnswer `json:"answers"`
 	Created  int           `json:"created"`   // Date when poll has been created in Unixtime
-	IsClosed int           `json:"is_closed"` // Information whether the poll is closed
+	IsClosed BaseBoolInt   `json:"is_closed"` // Information whether the poll is closed
 	OwnerID  int           `json:"owner_id"`  // Poll owner's ID
 	PollID   int           `json:"poll_id"`   // Poll ID
 	Question string        `json:"question"`  // Poll question

--- a/object/database.go
+++ b/object/database.go
@@ -2,11 +2,11 @@ package object // import "github.com/SevereCloud/vksdk/object"
 
 // DatabaseCity struct
 type DatabaseCity struct {
-	ID        int    `json:"id"`    // City ID
-	Title     string `json:"title"` // City title
-	Area      string `json:"area"`
-	Region    string `json:"region"`
-	Important int    `json:"important"`
+	ID        int         `json:"id"`    // City ID
+	Title     string      `json:"title"` // City title
+	Area      string      `json:"area"`
+	Region    string      `json:"region"`
+	Important BaseBoolInt `json:"important"`
 }
 
 // DatabaseMetroStation  struct

--- a/object/docs.go
+++ b/object/docs.go
@@ -10,7 +10,7 @@ type DocsDoc struct {
 	Date       int            `json:"date"`       // Date when file has been uploaded in Unixtime
 	Ext        string         `json:"ext"`        // File extension
 	ID         int            `json:"id"`         // Document ID
-	IsLicensed int            `json:"is_licensed"`
+	IsLicensed BaseBoolInt    `json:"is_licensed"`
 	OwnerID    int            `json:"owner_id"` // Document owner ID
 	Preview    DocsDocPreview `json:"preview"`
 	Size       int            `json:"size"`  // File size in bites

--- a/object/fave.go
+++ b/object/fave.go
@@ -23,14 +23,14 @@ type FaveFavesLink struct {
 	Caption     string      `json:"caption"`
 	Description string      `json:"description"`
 	Photo       PhotosPhoto `json:"photo"`
-	IsFavorite  bool        `json:"is_favorite"`
+	IsFavorite  BaseBoolInt `json:"is_favorite"`
 	ID          string      `json:"id"`
 }
 
 //FaveItem struct
 type FaveItem struct {
 	Type      string           `json:"type"`
-	Seen      bool             `json:"seen"`
+	Seen      BaseBoolInt      `json:"seen"`
 	AddedDate int              `json:"added_date"`
 	Tags      []FaveTag        `json:"tags"`
 	Link      FaveFavesLink    `json:"link,omitempty"`

--- a/object/friends.go
+++ b/object/friends.go
@@ -2,11 +2,11 @@ package object // import "github.com/SevereCloud/vksdk/object"
 
 // FriendsFriendStatus struct
 type FriendsFriendStatus struct {
-	FriendStatus   int    `json:"friend_status"`
-	ReadState      int    `json:"read_state"`      // Information whether request is unviewed
-	RequestMessage string `json:"request_message"` // Message sent with request
-	Sign           string `json:"sign"`            // MD5 hash for the result validation
-	UserID         int    `json:"user_id"`         // User ID
+	FriendStatus   int         `json:"friend_status"`
+	ReadState      BaseBoolInt `json:"read_state"`      // Information whether request is unviewed
+	RequestMessage string      `json:"request_message"` // Message sent with request
+	Sign           string      `json:"sign"`            // MD5 hash for the result validation
+	UserID         int         `json:"user_id"`         // User ID
 }
 
 // FriendsFriendsList struct

--- a/object/groups.go
+++ b/object/groups.go
@@ -43,70 +43,69 @@ type GroupsAddressTimetableDay struct {
 
 // GroupsAddressesInfo struct
 type GroupsAddressesInfo struct {
-	IsEnabled     bool `json:"is_enabled"`      // Information whether addresses is enabled
-	MainAddressID int  `json:"main_address_id"` // Main address id for group
+	IsEnabled     BaseBoolInt `json:"is_enabled"`      // Information whether addresses is enabled
+	MainAddressID int         `json:"main_address_id"` // Main address id for group
 }
 
 // GroupsGroup struct
 type GroupsGroup struct {
-	AdminLevel   int    `json:"admin_level"`
-	Deactivated  string `json:"deactivated"`   // Information whether community is banned
-	FinishDate   int    `json:"finish_date"`   // Finish date in Unixtime format
-	ID           int    `json:"id"`            // Community ID
-	IsAdmin      int    `json:"is_admin"`      // Information whether current user is administrator
-	IsAdvertiser int    `json:"is_advertiser"` // Information whether current user is advertiser
-	IsClosed     int    `json:"is_closed"`
-	IsMember     int    `json:"is_member"`   // Information whether current user is member
-	Name         string `json:"name"`        // Community name
-	Photo100     string `json:"photo_100"`   // URL of square photo of the community with 100 pixels in width
-	Photo200     string `json:"photo_200"`   // URL of square photo of the community with 200 pixels in width
-	Photo50      string `json:"photo_50"`    // URL of square photo of the community with 50 pixels in width
-	ScreenName   string `json:"screen_name"` // Domain of the community page
-	StartDate    int    `json:"start_date"`  // Start date in Unixtime format
-	Type         string `json:"type"`
-
+	AdminLevel           int                  `json:"admin_level"`
+	Deactivated          string               `json:"deactivated"` // Information whether community is banned
+	FinishDate           int                  `json:"finish_date"` // Finish date in Unixtime format
+	ID                   int                  `json:"id"`          // Community ID
+	Name                 string               `json:"name"`        // Community name
+	Photo100             string               `json:"photo_100"`   // URL of square photo of the community with 100 pixels in width
+	Photo200             string               `json:"photo_200"`   // URL of square photo of the community with 200 pixels in width
+	Photo50              string               `json:"photo_50"`    // URL of square photo of the community with 50 pixels in width
+	ScreenName           string               `json:"screen_name"` // Domain of the community page
+	StartDate            int                  `json:"start_date"`  // Start date in Unixtime format
+	Type                 string               `json:"type"`
 	Market               GroupsMarketInfo     `json:"market"`
 	MemberStatus         int                  `json:"member_status"` // Current user's member status
-	IsFavorite           int                  `json:"is_favorite"`   // Information whether community is in faves
-	IsAdult              int                  `json:"adult"`         // Information whether community is adult
-	IsSubscribed         int                  `json:"is_subscribed"` // Information whether current user is subscribed
 	City                 BaseObject           `json:"city"`
 	Country              BaseCountry          `json:"country"`
-	Verified             int                  `json:"verified"`      // Information whether community is verified
+	IsAdmin              BaseBoolInt          `json:"is_admin"`      // Information whether current user is administrator
+	IsAdvertiser         BaseBoolInt          `json:"is_advertiser"` // Information whether current user is advertiser
+	IsClosed             BaseBoolInt          `json:"is_closed"`
+	IsMember             BaseBoolInt          `json:"is_member"`              // Information whether current user is member
+	IsFavorite           BaseBoolInt          `json:"is_favorite"`            // Information whether community is in faves
+	IsAdult              BaseBoolInt          `json:"adult"`                  // Information whether community is adult
+	IsSubscribed         BaseBoolInt          `json:"is_subscribed"`          // Information whether current user is subscribed
+	CanPost              BaseBoolInt          `json:"can_post"`               // Information whether current user can post on community's wall
+	CanSeeAllPosts       BaseBoolInt          `json:"can_see_all_posts"`      // Information whether current user can see all posts on community's wall
+	CanCreateTopic       BaseBoolInt          `json:"can_create_topic"`       // Information whether current user can create topic
+	CanUploadVideo       BaseBoolInt          `json:"can_upload_video"`       // Information whether current user can upload video
+	CanUploadDoc         BaseBoolInt          `json:"can_upload_doc"`         // Information whether current user can upload doc
+	HasPhoto             BaseBoolInt          `json:"has_photo"`              // Information whether community has photo
+	CanMessage           BaseBoolInt          `json:"can_message"`            // Information whether current user can send a message to community
+	IsMessagesBlocked    BaseBoolInt          `json:"is_messages_blocked"`    // Information whether community can send a message to current user
+	CanSendNotify        BaseBoolInt          `json:"can_send_notify"`        // Information whether community can send notifications by phone number to current user
+	IsSubscribedPodcasts BaseBoolInt          `json:"is_subscribed_podcasts"` // Information whether current user is subscribed to podcasts
+	CanSubscribePodcasts BaseBoolInt          `json:"can_subscribe_podcasts"` // Owner in whitelist or not
+	CanSubscribePosts    BaseBoolInt          `json:"can_subscribe_posts"`    // Can subscribe to wall
+	HasMarketApp         BaseBoolInt          `json:"has_market_app"`         // Information whether community has market app
+	IsHiddenFromFeed     BaseBoolInt          `json:"is_hidden_from_feed"`
+	Verified             BaseBoolInt          `json:"verified"`      // Information whether community is verified
+	Trending             BaseBoolInt          `json:"trending"`      // Information whether the community has a fire pictogram.
 	Description          string               `json:"description"`   // Community description
 	WikiPage             string               `json:"wiki_page"`     // Community's main wiki page title
 	MembersCount         int                  `json:"members_count"` // Community members number
 	Counters             GroupsCountersGroup  `json:"counters"`
 	Cover                GroupsCover          `json:"cover"`
-	CanPost              int                  `json:"can_post"`          // Information whether current user can post on community's wall
-	CanSeeAllPosts       int                  `json:"can_see_all_posts"` // Information whether current user can see all posts on community's wall
-	Activity             string               `json:"activity"`          // Type of group, start date of event or category of public page
-	FixedPost            int                  `json:"fixed_post"`        // Fixed post ID
-	CanCreateTopic       int                  `json:"can_create_topic"`  // Information whether current user can create topic
-	CanUploadVideo       int                  `json:"can_upload_video"`  // Information whether current user can upload video
-	CanUploadDoc         int                  `json:"can_upload_doc"`    // Information whether current user can upload doc
-	HasPhoto             int                  `json:"has_photo"`         // Information whether community has photo
-	Status               string               `json:"status"`            // Community status
-	MainAlbumID          int                  `json:"main_album_id"`     // Community's main photo album ID
+	Activity             string               `json:"activity"`      // Type of group, start date of event or category of public page
+	FixedPost            int                  `json:"fixed_post"`    // Fixed post ID
+	Status               string               `json:"status"`        // Community status
+	MainAlbumID          int                  `json:"main_album_id"` // Community's main photo album ID
 	Links                []GroupsLinksItem    `json:"links"`
 	Contacts             []GroupsContactsItem `json:"contacts"`
 	Site                 string               `json:"site"` // Community's website
 	MainSection          int                  `json:"main_section"`
-	Trending             int                  `json:"trending"`               // Information whether the community has a fire pictogram.
-	CanMessage           int                  `json:"can_message"`            // Information whether current user can send a message to community
-	IsMessagesBlocked    int                  `json:"is_messages_blocked"`    // Information whether community can send a message to current user
-	CanSendNotify        int                  `json:"can_send_notify"`        // Information whether community can send notifications by phone number to current user
-	OnlineStatus         GroupsOnlineStatus   `json:"online_status"`          // Status of replies in community messages
-	AgeLimits            int                  `json:"age_limits"`             // Information whether age limit
-	BanInfo              GroupsGroupBanInfo   `json:"ban_info"`               // User ban info
-	Addresses            GroupsAddressesInfo  `json:"addresses"`              // Info about addresses in Groups
-	IsSubscribedPodcasts bool                 `json:"is_subscribed_podcasts"` // Information whether current user is subscribed to podcasts
-	CanSubscribePodcasts bool                 `json:"can_subscribe_podcasts"` // Owner in whitelist or not
-	CanSubscribePosts    bool                 `json:"can_subscribe_posts"`    // Can subscribe to wall
-	HasMarketApp         bool                 `json:"has_market_app"`         // Information whether community has market app
+	OnlineStatus         GroupsOnlineStatus   `json:"online_status"` // Status of replies in community messages
+	AgeLimits            int                  `json:"age_limits"`    // Information whether age limit
+	BanInfo              GroupsGroupBanInfo   `json:"ban_info"`      // User ban info
+	Addresses            GroupsAddressesInfo  `json:"addresses"`     // Info about addresses in Groups
 	LiveCovers           GroupsLiveCovers     `json:"live_covers"`
 	CropPhoto            UsersCropPhoto       `json:"crop_photo"`
-	IsHiddenFromFeed     int                  `json:"is_hidden_from_feed"`
 	Wall                 int                  `json:"wall"`
 }
 
@@ -117,19 +116,19 @@ func (group GroupsGroup) ToMention() string {
 
 // GroupsLiveCovers struct
 type GroupsLiveCovers struct {
-	IsEnabled  bool     `json:"is_enabled"`
-	IsScalable bool     `json:"is_scalable"`
-	StoryIds   []string `json:"story_ids"`
+	IsEnabled  BaseBoolInt `json:"is_enabled"`
+	IsScalable BaseBoolInt `json:"is_scalable"`
+	StoryIds   []string    `json:"story_ids"`
 }
 
 // GroupsBanInfo struct
 type GroupsBanInfo struct {
-	AdminID        int    `json:"admin_id"` // Administrator ID
-	Comment        string `json:"comment"`  // Comment for a ban
-	Date           int    `json:"date"`     // Date when user has been added to blacklist in Unixtime
-	EndDate        int    `json:"end_date"` // Date when user will be removed from blacklist in Unixtime
-	Reason         int    `json:"reason"`
-	CommentVisible bool   `json:"comment_visible"`
+	AdminID        int         `json:"admin_id"` // Administrator ID
+	Comment        string      `json:"comment"`  // Comment for a ban
+	Date           int         `json:"date"`     // Date when user has been added to blacklist in Unixtime
+	EndDate        int         `json:"end_date"` // Date when user will be removed from blacklist in Unixtime
+	Reason         int         `json:"reason"`
+	CommentVisible BaseBoolInt `json:"comment_visible"`
 }
 
 // GroupsCallbackServer struct
@@ -170,7 +169,7 @@ type GroupsCountersGroup struct {
 
 // GroupsCover struct
 type GroupsCover struct {
-	Enabled int         `json:"enabled"` // Information whether cover is enabled
+	Enabled BaseBoolInt `json:"enabled"` // Information whether cover is enabled
 	Images  []BaseImage `json:"images"`
 }
 
@@ -204,12 +203,12 @@ type GroupsGroupCategoryType struct {
 
 // GroupsGroupLink struct
 type GroupsGroupLink struct {
-	Desc            string `json:"desc"`       // Link description
-	EditTitle       int    `json:"edit_title"` // Information whether the title can be edited
-	Name            string `json:"name"`
-	ID              int    `json:"id"`               // Link ID
-	ImageProcessing int    `json:"image_processing"` // Information whether the image on processing
-	URL             string `json:"url"`              // Link URL
+	Desc            string      `json:"desc"`             // Link description
+	EditTitle       BaseBoolInt `json:"edit_title"`       // Information whether the title can be edited
+	ImageProcessing BaseBoolInt `json:"image_processing"` // Information whether the image on processing
+	Name            string      `json:"name"`
+	ID              int         `json:"id"`  // Link ID
+	URL             string      `json:"url"` // Link URL
 }
 
 // GroupsGroupPublicCategoryList struct
@@ -221,16 +220,14 @@ type GroupsGroupPublicCategoryList struct {
 
 // GroupsGroupSettings struct
 type GroupsGroupSettings struct {
-	Access             int                             `json:"access"`            // Community access settings
-	Address            string                          `json:"address"`           // Community's page domain
-	Audio              int                             `json:"audio"`             // Audio settings
-	Description        string                          `json:"description"`       // Community description
-	Docs               int                             `json:"docs"`              // Docs settings
-	ObsceneFilter      int                             `json:"obscene_filter"`    // Information whether the obscene filter is enabled
-	ObsceneStopwords   int                             `json:"obscene_stopwords"` // Information whether the stopwords filter is enabled
-	ObsceneWords       []string                        `json:"obscene_words"`     // The list of stop words
-	Photos             int                             `json:"photos"`            // Photos settings
-	PublicCategory     int                             `json:"public_category"`   // Information about the group category
+	Access             int                             `json:"access"`          // Community access settings
+	Address            string                          `json:"address"`         // Community's page domain
+	Audio              int                             `json:"audio"`           // Audio settings
+	Description        string                          `json:"description"`     // Community description
+	Docs               int                             `json:"docs"`            // Docs settings
+	ObsceneWords       []string                        `json:"obscene_words"`   // The list of stop words
+	Photos             int                             `json:"photos"`          // Photos settings
+	PublicCategory     int                             `json:"public_category"` // Information about the group category
 	PublicCategoryList []GroupsGroupPublicCategoryList `json:"public_category_list"`
 	PublicSubcategory  int                             `json:"public_subcategory"` // Information about the group subcategory
 	Rss                string                          `json:"rss"`                // URL of the RSS feed
@@ -248,11 +245,16 @@ type GroupsGroupSettings struct {
 	Articles           int                             `json:"articles"`
 	Events             int                             `json:"events"`
 	AgeLimits          int                             `json:"age_limits"`
-	Market             struct {
-		Enabled         int   `json:"enabled"`
-		CommentsEnabled int   `json:"comments_enabled"`
-		CountryIDs      []int `json:"country_ids"`
-		ContactID       int   `json:"contact_id"`
+	ObsceneFilter      BaseBoolInt                     `json:"obscene_filter"`    // Information whether the obscene filter is enabled
+	ObsceneStopwords   BaseBoolInt                     `json:"obscene_stopwords"` // Information whether the stopwords filter is enabled
+	LiveCovers         struct {
+		IsEnabled BaseBoolInt `json:"is_enabled"`
+	} `json:"live_covers"`
+	Market struct {
+		Enabled         BaseBoolInt `json:"enabled"`
+		CommentsEnabled BaseBoolInt `json:"comments_enabled"`
+		CountryIDs      []int       `json:"country_ids"`
+		ContactID       int         `json:"contact_id"`
 		Currency        struct {
 			ID   int    `json:"id"`
 			Name string `json:"name"`
@@ -266,26 +268,23 @@ type GroupsGroupSettings struct {
 		Target     []interface{} `json:"target"`
 		Title      string        `json:"title"`
 	} `json:"action_button"`
-	LiveCovers struct {
-		IsEnabled bool `json:"is_enabled"`
-	} `json:"live_covers"`
 }
 
 // GroupsGroupXtrInvitedBy struct
 type GroupsGroupXtrInvitedBy struct {
-	AdminLevel   int    `json:"admin_level"`
-	ID           int    `json:"id"`          // Community ID
-	InvitedBy    int    `json:"invited_by"`  // Inviter ID
-	IsAdmin      int    `json:"is_admin"`    // Information whether current user is manager
-	IsClosed     int    `json:"is_closed"`   // Information whether community is closed
-	IsMember     int    `json:"is_member"`   // Information whether current user is member
-	Name         string `json:"name"`        // Community name
-	Photo100     string `json:"photo_100"`   // URL of square photo of the community with 100 pixels in width
-	Photo200     string `json:"photo_200"`   // URL of square photo of the community with 200 pixels in width
-	Photo50      string `json:"photo_50"`    // URL of square photo of the community with 50 pixels in width
-	ScreenName   string `json:"screen_name"` // Domain of the community page
-	Type         string `json:"type"`
-	IsAdvertiser int    `json:"is_advertiser"` // Information whether current user is advertiser
+	AdminLevel   int         `json:"admin_level"`
+	ID           int         `json:"id"`          // Community ID
+	InvitedBy    int         `json:"invited_by"`  // Inviter ID
+	Name         string      `json:"name"`        // Community name
+	Photo100     string      `json:"photo_100"`   // URL of square photo of the community with 100 pixels in width
+	Photo200     string      `json:"photo_200"`   // URL of square photo of the community with 200 pixels in width
+	Photo50      string      `json:"photo_50"`    // URL of square photo of the community with 50 pixels in width
+	ScreenName   string      `json:"screen_name"` // Domain of the community page
+	Type         string      `json:"type"`
+	IsAdmin      BaseBoolInt `json:"is_admin"`      // Information whether current user is manager
+	IsClosed     BaseBoolInt `json:"is_closed"`     // Information whether community is closed
+	IsMember     BaseBoolInt `json:"is_member"`     // Information whether current user is member
+	IsAdvertiser BaseBoolInt `json:"is_advertiser"` // Information whether current user is advertiser
 }
 
 // ToMention return mention
@@ -295,63 +294,63 @@ func (group GroupsGroupXtrInvitedBy) ToMention() string {
 
 // GroupsLinksItem struct
 type GroupsLinksItem struct {
-	Desc      string `json:"desc"`       // Link description
-	EditTitle int    `json:"edit_title"` // Information whether the link title can be edited
-	ID        int    `json:"id"`         // Link ID
-	Name      string `json:"name"`       // Link title
-	Photo100  string `json:"photo_100"`  // URL of square image of the link with 100 pixels in width
-	Photo50   string `json:"photo_50"`   // URL of square image of the link with 50 pixels in width
-	URL       string `json:"url"`        // Link URL
+	Desc      string      `json:"desc"`       // Link description
+	EditTitle BaseBoolInt `json:"edit_title"` // Information whether the link title can be edited
+	ID        int         `json:"id"`         // Link ID
+	Name      string      `json:"name"`       // Link title
+	Photo100  string      `json:"photo_100"`  // URL of square image of the link with 100 pixels in width
+	Photo50   string      `json:"photo_50"`   // URL of square image of the link with 50 pixels in width
+	URL       string      `json:"url"`        // Link URL
 }
 
 // GroupsLongPollEvents struct
 type GroupsLongPollEvents struct {
-	MessageNew           int `json:"message_new"`
-	MessageReply         int `json:"message_reply"`
-	PhotoNew             int `json:"photo_new"`
-	AudioNew             int `json:"audio_new"`
-	VideoNew             int `json:"video_new"`
-	WallReplyNew         int `json:"wall_reply_new"`
-	WallReplyEdit        int `json:"wall_reply_edit"`
-	WallReplyDelete      int `json:"wall_reply_delete"`
-	WallReplyRestore     int `json:"wall_reply_restore"`
-	WallPostNew          int `json:"wall_post_new"`
-	BoardPostNew         int `json:"board_post_new"`
-	BoardPostEdit        int `json:"board_post_edit"`
-	BoardPostRestore     int `json:"board_post_restore"`
-	BoardPostDelete      int `json:"board_post_delete"`
-	PhotoCommentNew      int `json:"photo_comment_new"`
-	PhotoCommentEdit     int `json:"photo_comment_edit"`
-	PhotoCommentDelete   int `json:"photo_comment_delete"`
-	PhotoCommentRestore  int `json:"photo_comment_restore"`
-	VideoCommentNew      int `json:"video_comment_new"`
-	VideoCommentEdit     int `json:"video_comment_edit"`
-	VideoCommentDelete   int `json:"video_comment_delete"`
-	VideoCommentRestore  int `json:"video_comment_restore"`
-	MarketCommentNew     int `json:"market_comment_new"`
-	MarketCommentEdit    int `json:"market_comment_edit"`
-	MarketCommentDelete  int `json:"market_comment_delete"`
-	MarketCommentRestore int `json:"market_comment_restore"`
-	PollVoteNew          int `json:"poll_vote_new"`
-	GroupJoin            int `json:"group_join"`
-	GroupLeave           int `json:"group_leave"`
-	GroupChangeSettings  int `json:"group_change_settings"`
-	GroupChangePhoto     int `json:"group_change_photo"`
-	GroupOfficersEdit    int `json:"group_officers_edit"`
-	MessageAllow         int `json:"message_allow"`
-	MessageDeny          int `json:"message_deny"`
-	WallRepost           int `json:"wall_repost"`
-	UserBlock            int `json:"user_block"`
-	UserUnblock          int `json:"user_unblock"`
-	MessageEdit          int `json:"message_edit"`
-	MessagesEdit         int `json:"messages_edit"` // BUG(VK): https://vk.com/bugtracker?act=show&id=86762
-	MessageTypingState   int `json:"message_typing_state"`
-	LeadFormsNew         int `json:"lead_forms_new"`
-	LikeAdd              int `json:"like_add"`
-	LikeRemove           int `json:"like_remove"`
-	VkpayTransaction     int `json:"vkpay_transaction"`
-	AppPayload           int `json:"app_payload"`
-	MessageRead          int `json:"message_read"`
+	MessageNew           BaseBoolInt `json:"message_new"`
+	MessageReply         BaseBoolInt `json:"message_reply"`
+	PhotoNew             BaseBoolInt `json:"photo_new"`
+	AudioNew             BaseBoolInt `json:"audio_new"`
+	VideoNew             BaseBoolInt `json:"video_new"`
+	WallReplyNew         BaseBoolInt `json:"wall_reply_new"`
+	WallReplyEdit        BaseBoolInt `json:"wall_reply_edit"`
+	WallReplyDelete      BaseBoolInt `json:"wall_reply_delete"`
+	WallReplyRestore     BaseBoolInt `json:"wall_reply_restore"`
+	WallPostNew          BaseBoolInt `json:"wall_post_new"`
+	BoardPostNew         BaseBoolInt `json:"board_post_new"`
+	BoardPostEdit        BaseBoolInt `json:"board_post_edit"`
+	BoardPostRestore     BaseBoolInt `json:"board_post_restore"`
+	BoardPostDelete      BaseBoolInt `json:"board_post_delete"`
+	PhotoCommentNew      BaseBoolInt `json:"photo_comment_new"`
+	PhotoCommentEdit     BaseBoolInt `json:"photo_comment_edit"`
+	PhotoCommentDelete   BaseBoolInt `json:"photo_comment_delete"`
+	PhotoCommentRestore  BaseBoolInt `json:"photo_comment_restore"`
+	VideoCommentNew      BaseBoolInt `json:"video_comment_new"`
+	VideoCommentEdit     BaseBoolInt `json:"video_comment_edit"`
+	VideoCommentDelete   BaseBoolInt `json:"video_comment_delete"`
+	VideoCommentRestore  BaseBoolInt `json:"video_comment_restore"`
+	MarketCommentNew     BaseBoolInt `json:"market_comment_new"`
+	MarketCommentEdit    BaseBoolInt `json:"market_comment_edit"`
+	MarketCommentDelete  BaseBoolInt `json:"market_comment_delete"`
+	MarketCommentRestore BaseBoolInt `json:"market_comment_restore"`
+	PollVoteNew          BaseBoolInt `json:"poll_vote_new"`
+	GroupJoin            BaseBoolInt `json:"group_join"`
+	GroupLeave           BaseBoolInt `json:"group_leave"`
+	GroupChangeSettings  BaseBoolInt `json:"group_change_settings"`
+	GroupChangePhoto     BaseBoolInt `json:"group_change_photo"`
+	GroupOfficersEdit    BaseBoolInt `json:"group_officers_edit"`
+	MessageAllow         BaseBoolInt `json:"message_allow"`
+	MessageDeny          BaseBoolInt `json:"message_deny"`
+	WallRepost           BaseBoolInt `json:"wall_repost"`
+	UserBlock            BaseBoolInt `json:"user_block"`
+	UserUnblock          BaseBoolInt `json:"user_unblock"`
+	MessageEdit          BaseBoolInt `json:"message_edit"`
+	MessagesEdit         BaseBoolInt `json:"messages_edit"` // BUG(VK): https://vk.com/bugtracker?act=show&id=86762
+	MessageTypingState   BaseBoolInt `json:"message_typing_state"`
+	LeadFormsNew         BaseBoolInt `json:"lead_forms_new"`
+	LikeAdd              BaseBoolInt `json:"like_add"`
+	LikeRemove           BaseBoolInt `json:"like_remove"`
+	VkpayTransaction     BaseBoolInt `json:"vkpay_transaction"`
+	AppPayload           BaseBoolInt `json:"app_payload"`
+	MessageRead          BaseBoolInt `json:"message_read"`
 }
 
 // GroupsLongPollServer struct
@@ -367,7 +366,7 @@ type GroupsLongPollServer struct {
 type GroupsLongPollSettings struct {
 	APIVersion string               `json:"api_version"` // API version used for the events
 	Events     GroupsLongPollEvents `json:"events"`
-	IsEnabled  bool                 `json:"is_enabled"` // Shows whether Long Poll is enabled
+	IsEnabled  BaseBoolInt          `json:"is_enabled"` // Shows whether Long Poll is enabled
 }
 
 // GroupsMarketInfo struct
@@ -375,7 +374,7 @@ type GroupsMarketInfo struct {
 	ContactID    int            `json:"contact_id"` // Contact person ID
 	Currency     MarketCurrency `json:"currency"`
 	CurrencyText string         `json:"currency_text"` // Currency name
-	Enabled      int            `json:"enabled"`       // Information whether the market is enabled
+	Enabled      BaseBoolInt    `json:"enabled"`       // Information whether the market is enabled
 	MainAlbumID  int            `json:"main_album_id"` // Main market album ID
 	PriceMax     string         `json:"price_max"`     // Maximum price
 	PriceMin     string         `json:"price_min"`     // Minimum price
@@ -389,19 +388,19 @@ type GroupsMemberRole struct {
 
 // GroupsMemberStatus struct
 type GroupsMemberStatus struct {
-	Member      int      `json:"member"`  // Information whether user is a member of the group
-	UserID      int      `json:"user_id"` // User ID
-	Permissions []string `json:"permissions"`
+	Member      BaseBoolInt `json:"member"`  // Information whether user is a member of the group
+	UserID      int         `json:"user_id"` // User ID
+	Permissions []string    `json:"permissions"`
 }
 
 // GroupsMemberStatusFull struct
 type GroupsMemberStatusFull struct {
-	Invitation int `json:"invitation"` // Information whether user has been invited to the group
-	Member     int `json:"member"`     // Information whether user is a member of the group
-	Request    int `json:"request"`    // Information whether user has send request to the group
-	CanInvite  int `json:"can_invite"` // Information whether user can be invite
-	CanRecall  int `json:"can_recall"` // Information whether user's invite to the group can be recalled
-	UserID     int `json:"user_id"`    // User ID
+	Invitation BaseBoolInt `json:"invitation"` // Information whether user has been invited to the group
+	Member     BaseBoolInt `json:"member"`     // Information whether user is a member of the group
+	Request    BaseBoolInt `json:"request"`    // Information whether user has send request to the group
+	CanInvite  BaseBoolInt `json:"can_invite"` // Information whether user can be invite
+	CanRecall  BaseBoolInt `json:"can_recall"` // Information whether user's invite to the group can be recalled
+	UserID     int         `json:"user_id"`    // User ID
 }
 
 // GroupsOnlineStatus struct

--- a/object/handler.go
+++ b/object/handler.go
@@ -260,8 +260,8 @@ type GroupLeaveFunc func(GroupLeaveObject, int)
 
 // GroupLeaveObject struct
 type GroupLeaveObject struct {
-	UserID int `json:"user_id"`
-	Self   int `json:"self"`
+	UserID int         `json:"user_id"`
+	Self   BaseBoolInt `json:"self"`
 }
 
 // GroupJoinFunc func

--- a/object/leads.go
+++ b/object/leads.go
@@ -10,23 +10,23 @@ type LeadsChecked struct {
 
 // LeadsComplete struct
 type LeadsComplete struct {
-	Cost     int `json:"cost"`  // Offer cost
-	Limit    int `json:"limit"` // Offer limit
-	Spent    int `json:"spent"` // Amount of spent votes
-	Success  int `json:"success"`
-	TestMode int `json:"test_mode"` // Information whether test mode is enabled
+	Cost     int         `json:"cost"`  // Offer cost
+	Limit    int         `json:"limit"` // Offer limit
+	Spent    int         `json:"spent"` // Amount of spent votes
+	Success  BaseBoolInt `json:"success"`
+	TestMode BaseBoolInt `json:"test_mode"` // Information whether test mode is enabled
 }
 
 // LeadsEntry struct
 type LeadsEntry struct {
-	Aid       int    `json:"aid"`        // Application ID
-	Comment   string `json:"comment"`    // Comment text
-	Date      int    `json:"date"`       // Date when the action has been started in Unixtime
-	Sid       string `json:"sid"`        // Session string ID
-	StartDate int    `json:"start_date"` // Start date in Unixtime (for status=2)
-	Status    int    `json:"status"`     // Action type
-	TestMode  int    `json:"test_mode"`  // Information whether test mode is enabled
-	UID       int    `json:"uid"`        // User ID
+	Aid       int         `json:"aid"`        // Application ID
+	Comment   string      `json:"comment"`    // Comment text
+	Date      int         `json:"date"`       // Date when the action has been started in Unixtime
+	Sid       string      `json:"sid"`        // Session string ID
+	StartDate int         `json:"start_date"` // Start date in Unixtime (for status=2)
+	Status    int         `json:"status"`     // Action type
+	TestMode  BaseBoolInt `json:"test_mode"`  // Information whether test mode is enabled
+	UID       int         `json:"uid"`        // User ID
 }
 
 // LeadsLead struct
@@ -50,6 +50,6 @@ type LeadsLeadDays struct {
 
 // LeadsStart struct
 type LeadsStart struct {
-	TestMode int    `json:"test_mode"` // Information whether test mode is enabled
-	VkSid    string `json:"vk_sid"`    // Session data
+	TestMode BaseBoolInt `json:"test_mode"` // Information whether test mode is enabled
+	VkSid    string      `json:"vk_sid"`    // Session data
 }

--- a/object/market.go
+++ b/object/market.go
@@ -44,11 +44,11 @@ type MarketMarketItem struct {
 	Price        MarketPrice          `json:"price"`
 	ThumbPhoto   string               `json:"thumb_photo"` // URL of the preview image
 	Title        string               `json:"title"`       // Item title
-	IsFavorite   bool                 `json:"is_favorite"`
+	CanComment   BaseBoolInt          `json:"can_comment"`
+	CanRepost    BaseBoolInt          `json:"can_repost"`
+	IsFavorite   BaseBoolInt          `json:"is_favorite"`
 	AlbumsIDs    []int                `json:"albums_ids"`
 	Photos       []PhotosPhoto        `json:"photos"`
-	CanComment   int                  `json:"can_comment"`
-	CanRepost    int                  `json:"can_repost"`
 	Likes        BaseLikesInfo        `json:"likes"`
 	Reposts      BaseRepostsInfo      `json:"reposts"`
 	ViewsCount   int                  `json:"views_count"`

--- a/object/messages.go
+++ b/object/messages.go
@@ -43,18 +43,18 @@ type MessagesMessage struct {
 	Attachments           []MessagesMessageAttachment `json:"attachments"`
 	ConversationMessageID int                         `json:"conversation_message_id"` // Unique auto-incremented number for all messages with this peer
 	Date                  int                         `json:"date"`                    // Date when the message has been sent in Unixtime
-	Deleted               int                         `json:"deleted"`                 // Is it an deleted message
 	FromID                int                         `json:"from_id"`                 // Message author's ID
 	FwdMessages           []MessagesMessage           `json:"fwd_Messages"`            // Forwarded messages
 	ReplyMessage          *MessagesMessage            `json:"reply_message"`
 	Geo                   BaseGeo                     `json:"geo"`
 	ID                    int                         `json:"id"`        // Message ID
-	Important             bool                        `json:"important"` // Is it an important message
-	IsHidden              bool                        `json:"is_hidden"`
-	IsCropped             bool                        `json:"is_cropped"`
+	Deleted               BaseBoolInt                 `json:"deleted"`   // Is it an deleted message
+	Important             BaseBoolInt                 `json:"important"` // Is it an important message
+	IsHidden              BaseBoolInt                 `json:"is_hidden"`
+	IsCropped             BaseBoolInt                 `json:"is_cropped"`
+	Out                   BaseBoolInt                 `json:"out"` // Information whether the message is outcoming
 	Keyboard              MessagesKeyboard            `json:"keyboard"`
 	Template              MessagesTemplate            `json:"template"`
-	Out                   int                         `json:"out"` // Information whether the message is outcoming
 	Payload               string                      `json:"payload"`
 	PeerID                int                         `json:"peer_id"`   // Peer ID
 	RandomID              int                         `json:"random_id"` // ID used for sending messages. It returned only for outgoing messages
@@ -69,12 +69,12 @@ type MessagesMessage struct {
 type MessagesKeyboard struct {
 	AuthorID int                        `json:"author_id,omitempty"` // Community or bot, which set this keyboard
 	Buttons  [][]MessagesKeyboardButton `json:"buttons"`
-	OneTime  bool                       `json:"one_time,omitempty"` // Should this keyboard disappear on first use
-	Inline   bool                       `json:"inline,omitempty"`
+	OneTime  BaseBoolInt                `json:"one_time,omitempty"` // Should this keyboard disappear on first use
+	Inline   BaseBoolInt                `json:"inline,omitempty"`
 }
 
 // NewMessagesKeyboard return MessagesKeyboard
-func NewMessagesKeyboard(oneTime bool) MessagesKeyboard {
+func NewMessagesKeyboard(oneTime BaseBoolInt) MessagesKeyboard {
 	return MessagesKeyboard{
 		Buttons: [][]MessagesKeyboardButton{},
 		OneTime: oneTime,
@@ -231,10 +231,11 @@ type MessagesTemplateElementCarouselAction struct {
 
 // MessagesChat struct
 type MessagesChat struct {
-	AdminID      int                       `json:"admin_id"`  // Chat creator ID
-	ID           int                       `json:"id"`        // Chat ID
-	Kicked       int                       `json:"kicked"`    // Shows that user has been kicked from the chat
-	Left         int                       `json:"left"`      // Shows that user has been left the chat
+	AdminID      int                       `json:"admin_id"` // Chat creator ID
+	ID           int                       `json:"id"`       // Chat ID
+	Kicked       BaseBoolInt               `json:"kicked"`   // Shows that user has been kicked from the chat
+	Left         BaseBoolInt               `json:"left"`     // Shows that user has been left the chat
+	Joined       BaseBoolInt               `json:"joined"`
 	Photo100     string                    `json:"photo_100"` // URL of the preview image with 100 px in width
 	Photo200     string                    `json:"photo_200"` // URL of the preview image with 200 px in width
 	Photo50      string                    `json:"photo_50"`  // URL of the preview image with 50 px in width
@@ -245,7 +246,6 @@ type MessagesChat struct {
 	MembersCount int                       `json:"members_count"`
 	Members      []int                     `json:"members"`
 	Photo        MessagesChatSettingsPhoto `json:"photo"`
-	Joined       bool                      `json:"joined"`
 	LocalID      int                       `json:"local_id"`
 }
 
@@ -253,8 +253,8 @@ type MessagesChat struct {
 type MessagesChatFull struct {
 	AdminID      int                        `json:"admin_id"`  // Chat creator ID
 	ID           int                        `json:"id"`        // Chat ID
-	Kicked       int                        `json:"kicked"`    // Shows that user has been kicked from the chat
-	Left         int                        `json:"left"`      // Shows that user has been left the chat
+	Kicked       BaseBoolInt                `json:"kicked"`    // Shows that user has been kicked from the chat
+	Left         BaseBoolInt                `json:"left"`      // Shows that user has been left the chat
 	Photo100     string                     `json:"photo_100"` // URL of the preview image with 100 px in width
 	Photo200     string                     `json:"photo_200"` // URL of the preview image with 200 px in width
 	Photo50      string                     `json:"photo_50"`  // URL of the preview image with 50 px in width
@@ -266,8 +266,8 @@ type MessagesChatFull struct {
 
 // MessagesChatPushSettings struct
 type MessagesChatPushSettings struct {
-	DisabledUntil int `json:"disabled_until"` // Time until that notifications are disabled
-	Sound         int `json:"sound"`          // Information whether the sound is on
+	DisabledUntil int         `json:"disabled_until"` // Time until that notifications are disabled
+	Sound         BaseBoolInt `json:"sound"`          // Information whether the sound is on
 }
 
 // MessagesChatSettingsPhoto struct
@@ -288,16 +288,16 @@ type MessagesConversation struct {
 	OutRead         int                              `json:"out_read"` // Last outcoming message have been read by the opponent
 	Peer            MessagesConversationPeer         `json:"peer"`
 	PushSettings    MessagesConversationPushSettings `json:"push_settings"`
-	Important       bool                             `json:"important"`
-	Unanswered      bool                             `json:"unanswered"`
+	Important       BaseBoolInt                      `json:"important"`
+	Unanswered      BaseBoolInt                      `json:"unanswered"`
 	UnreadCount     int                              `json:"unread_count"` // Unread messages number
 	CurrentKeyboard MessagesKeyboard                 `json:"current_keyboard"`
 }
 
 // MessagesConversationCanWrite struct
 type MessagesConversationCanWrite struct {
-	Allowed bool `json:"allowed"`
-	Reason  int  `json:"reason"`
+	Allowed BaseBoolInt `json:"allowed"`
+	Reason  int         `json:"reason"`
 }
 
 // MessagesConversationChatSettings struct
@@ -309,17 +309,17 @@ type MessagesConversationChatSettings struct {
 	Title         string                    `json:"title"`
 	ActiveIDS     []int                     `json:"active_ids"`
 	ACL           struct {
-		CanInvite           bool `json:"can_invite"`
-		CanChangeInfo       bool `json:"can_change_info"`
-		CanChangePin        bool `json:"can_change_pin"`
-		CanPromoteUsers     bool `json:"can_promote_users"`
-		CanSeeInviteLink    bool `json:"can_see_invite_link"`
-		CanChangeInviteLink bool `json:"can_change_invite_link"`
-		CanCopyChat         bool `json:"can_copy_chat"`
-		CanModerate         bool `json:"can_moderate"`
+		CanInvite           BaseBoolInt `json:"can_invite"`
+		CanChangeInfo       BaseBoolInt `json:"can_change_info"`
+		CanChangePin        BaseBoolInt `json:"can_change_pin"`
+		CanPromoteUsers     BaseBoolInt `json:"can_promote_users"`
+		CanSeeInviteLink    BaseBoolInt `json:"can_see_invite_link"`
+		CanChangeInviteLink BaseBoolInt `json:"can_change_invite_link"`
+		CanCopyChat         BaseBoolInt `json:"can_copy_chat"`
+		CanModerate         BaseBoolInt `json:"can_moderate"`
 	} `json:"acl"`
-	IsGroupChannel bool `json:"is_group_channel"`
-	OwnerID        int  `json:"owner_id"`
+	IsGroupChannel BaseBoolInt `json:"is_group_channel"`
+	OwnerID        int         `json:"owner_id"`
 }
 
 // MessagesConversationPeer struct
@@ -331,9 +331,9 @@ type MessagesConversationPeer struct {
 
 // MessagesConversationPushSettings struct
 type MessagesConversationPushSettings struct {
-	DisabledUntil   int  `json:"disabled_until"`
-	DisabledForever bool `json:"disabled_forever"`
-	NoSound         bool `json:"no_sound"`
+	DisabledUntil   int         `json:"disabled_until"`
+	DisabledForever BaseBoolInt `json:"disabled_forever"`
+	NoSound         BaseBoolInt `json:"no_sound"`
 }
 
 // MessagesConversationWithMessage struct
@@ -373,8 +373,8 @@ type MessagesHistoryMessageAttachment struct {
 
 // MessagesLastActivity struct
 type MessagesLastActivity struct {
-	Online int `json:"online"` // Information whether user is online
-	Time   int `json:"time"`   // Time when user was online in Unixtime
+	Online BaseBoolInt `json:"online"` // Information whether user is online
+	Time   int         `json:"time"`   // Time when user was online in Unixtime
 }
 
 // MessagesLongpollParams struct
@@ -425,12 +425,12 @@ type MessagesMessageAttachment struct {
 
 // MessageCall struct
 type MessageCall struct {
-	InitiatorID int    `json:"initiator_id"`
-	ReceiverID  int    `json:"receiver_id"`
-	State       string `json:"state"`
-	Time        int    `json:"time"`
-	Duration    int    `json:"duration"`
-	Video       bool   `json:"video"`
+	InitiatorID int         `json:"initiator_id"`
+	ReceiverID  int         `json:"receiver_id"`
+	State       string      `json:"state"`
+	Time        int         `json:"time"`
+	Duration    int         `json:"duration"`
+	Video       BaseBoolInt `json:"video"`
 }
 
 // MessagesPinnedMessage struct

--- a/object/newsfeed.go
+++ b/object/newsfeed.go
@@ -117,7 +117,7 @@ type NewsfeedItemWallpost struct {
 	Reposts     BaseRepostsInfo          `json:"reposts"`
 	MarkedAsAds int                      `json:"marked_as_ads,omitempty"`
 	Views       interface{}              `json:"views,omitempty"` // BUG: Views int or wallViews
-	IsFavorite  bool                     `json:"is_favorite,omitempty"`
+	IsFavorite  BaseBoolInt              `json:"is_favorite,omitempty"`
 	SignerID    int                      `json:"signer_id,omitempty"`
 	Text        string                   `json:"text"` // Post text
 }
@@ -150,9 +150,9 @@ type NewsfeedNewsfeedItem struct {
 	NewsfeedItemDigest
 	NewsfeedItemStoriesBlock
 
-	CanEdit   int `json:"can_edit,omitempty"`
-	CreatedBy int `json:"created_by,omitempty"`
-	CanDelete int `json:"can_delete,omitempty"`
+	CreatedBy int         `json:"created_by,omitempty"`
+	CanEdit   BaseBoolInt `json:"can_edit,omitempty"`
+	CanDelete BaseBoolInt `json:"can_delete,omitempty"`
 	// TODO: Need more fields
 }
 

--- a/object/notes.go
+++ b/object/notes.go
@@ -6,7 +6,7 @@ import (
 
 // NotesNote struct
 type NotesNote struct {
-	CanComment     int           `json:"can_comment"` // Information whether current user can comment the note
+	CanComment     BaseBoolInt   `json:"can_comment"` // Information whether current user can comment the note
 	Comments       int           `json:"comments"`    // Comments number
 	Date           int           `json:"date"`        // Date when the note has been created in Unixtime
 	ID             int           `json:"id"`          // Note ID

--- a/object/object.go
+++ b/object/object.go
@@ -5,7 +5,11 @@ See more https://vk.com/dev/objects
 */
 package object // import "github.com/SevereCloud/vksdk/object"
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
 
 // Attachment interface
 type Attachment interface {
@@ -15,6 +19,23 @@ type Attachment interface {
 // JSONObject interface
 type JSONObject interface {
 	ToJSON() string
+}
+
+type BaseBoolInt bool
+
+// UnmarshalJSON func
+func (b *BaseBoolInt) UnmarshalJSON(data []byte) (err error) {
+	switch {
+	case bytes.Equal(data, []byte("1")), bytes.Equal(data, []byte("true")):
+		*b = true
+	case bytes.Equal(data, []byte("0")), bytes.Equal(data, []byte("false")):
+		*b = false
+	default:
+		// return json error
+		err = fmt.Errorf("json: cannot unmarshal ? into Go value of type BaseBoolInt")
+	}
+
+	return
 }
 
 // BaseCountry struct
@@ -71,11 +92,11 @@ type LongpollBotResponse struct {
 
 // BaseCommentsInfo struct
 type BaseCommentsInfo struct {
-	CanPost       int  `json:"can_post"`
-	Count         int  `json:"count"`
-	GroupsCanPost bool `json:"groups_can_post"`
-	CanClose      bool `json:"can_close"`
-	CanOpen       bool `json:"can_open"`
+	Count         int         `json:"count"`
+	CanPost       BaseBoolInt `json:"can_post"`
+	GroupsCanPost BaseBoolInt `json:"groups_can_post"`
+	CanClose      BaseBoolInt `json:"can_close"`
+	CanOpen       BaseBoolInt `json:"can_open"`
 }
 
 // BaseGeo struct
@@ -96,17 +117,16 @@ type BaseImage struct {
 
 // BaseLikes struct
 type BaseLikes struct {
-	Count     int `json:"count"`
-	UserLikes int `json:"user_likes"`
+	UserLikes BaseBoolInt `json:"user_likes"` // Information whether current user likes
+	Count     int         `json:"count"`      // Likes number
 }
 
 // BaseLikesInfo struct
 type BaseLikesInfo struct {
-	CanLike int `json:"can_like"`
-	// BUG(VK): https://github.com/SevereCloud/vksdk/issues/55
-	// CanPublish int `json:"can_publish"`
-	Count     int `json:"count"`
-	UserLikes int `json:"user_likes"`
+	CanLike    BaseBoolInt `json:"can_like"`    // Information whether current user can like the post
+	CanPublish BaseBoolInt `json:"can_publish"` // Information whether current user can repost
+	UserLikes  BaseBoolInt `json:"user_likes"`  // Information whether current uer has liked the post
+	Count      int         `json:"count"`       // Likes number
 }
 
 // BaseLink struct
@@ -174,7 +194,7 @@ type BasePlace struct {
 	Longitude      float64            `json:"longitude"`
 	Title          string             `json:"title"`
 	Type           string             `json:"type"`
-	IsDeleted      bool               `json:"is_deleted"`
+	IsDeleted      BaseBoolInt        `json:"is_deleted"`
 	TotalCheckins  int                `json:"total_checkins"`
 	Updated        int                `json:"updated"`
 	CategoryObject BaseCategoryObject `json:"category_object"`
@@ -208,14 +228,14 @@ type BaseUserID struct {
 
 // EventsEventAttach struct
 type EventsEventAttach struct {
-	Address      string `json:"address,omitempty"`       // address of event
-	ButtonText   string `json:"button_text"`             // text of attach
-	Friends      []int  `json:"friends"`                 // array of friends ids
-	ID           int    `json:"id"`                      // event ID
-	IsFavorite   bool   `json:"is_favorite"`             // is favorite
-	MemberStatus int    `json:"member_status,omitempty"` // Current user's member status
-	Text         string `json:"text"`                    // text of attach
-	Time         int    `json:"time,omitempty"`          // event start time
+	Address      string      `json:"address,omitempty"`       // address of event
+	ButtonText   string      `json:"button_text"`             // text of attach
+	Friends      []int       `json:"friends"`                 // array of friends ids
+	ID           int         `json:"id"`                      // event ID
+	IsFavorite   BaseBoolInt `json:"is_favorite"`             // is favorite
+	MemberStatus int         `json:"member_status,omitempty"` // Current user's member status
+	Text         string      `json:"text"`                    // text of attach
+	Time         int         `json:"time,omitempty"`          // event start time
 }
 
 // OauthError struct
@@ -232,8 +252,8 @@ type Article struct {
 	OwnerName     string      `json:"owner_name"`
 	OwnerPhoto    string      `json:"owner_photo"`
 	State         string      `json:"state"`
-	CanReport     bool        `json:"can_report"`
-	IsFavorite    bool        `json:"is_favorite"`
+	CanReport     BaseBoolInt `json:"can_report"`
+	IsFavorite    BaseBoolInt `json:"is_favorite"`
 	Title         string      `json:"title"`
 	Subtitle      string      `json:"subtitle"`
 	Views         int         `json:"views"`
@@ -263,11 +283,11 @@ type ExtendedResponse struct {
 
 // ClientInfo struct
 type ClientInfo struct {
-	ButtonActions  []string `json:"button_actions"`
-	Keyboard       bool     `json:"keyboard"`
-	InlineKeyboard bool     `json:"inline_keyboard"`
-	Carousel       bool     `json:"carousel"`
-	LangID         int      `json:"lang_id"`
+	ButtonActions  []string    `json:"button_actions"`
+	Keyboard       BaseBoolInt `json:"keyboard"`
+	InlineKeyboard BaseBoolInt `json:"inline_keyboard"`
+	Carousel       BaseBoolInt `json:"carousel"`
+	LangID         int         `json:"lang_id"`
 }
 
 // Language code

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -1,0 +1,33 @@
+/*
+Package object contains objects for VK.
+
+See more https://vk.com/dev/objects
+*/
+package object
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBaseBoolInt_UnmarshalJSON(t *testing.T) {
+	f := func(data []byte, want BaseBoolInt, wantErr string) {
+		t.Helper()
+
+		var b BaseBoolInt
+
+		err := b.UnmarshalJSON(data)
+		if err != nil {
+			assert.EqualError(t, err, wantErr)
+		}
+
+		assert.Equal(t, want, b)
+	}
+
+	f([]byte("1"), true, "")
+	f([]byte("true"), true, "")
+	f([]byte("0"), false, "")
+	f([]byte("false"), false, "")
+	f([]byte("null"), false, "json: cannot unmarshal ? into Go value of type BaseBoolInt")
+}

--- a/object/orders.go
+++ b/object/orders.go
@@ -29,17 +29,17 @@ type OrdersOrder struct {
 
 // OrdersSubscription struct
 type OrdersSubscription struct {
-	CancelReason    string `json:"cancel_reason"`     // Cancel reason
-	CreateTime      int    `json:"create_time"`       // Date of creation in Unixtime
-	ID              int    `json:"id"`                // Subscription ID
-	ItemID          string `json:"item_id"`           // Subscription order item
-	NextBillTime    int    `json:"next_bill_time"`    // Date of next bill in Unixtime
-	Period          int    `json:"period"`            // Subscription period
-	PeriodStartTime int    `json:"period_start_time"` // Date of last period start in Unixtime
-	Price           int    `json:"price"`             // Subscription price
-	Status          string `json:"status"`            // Subscription status
-	PendingCancel   bool   `json:"pending_cancel"`    // Pending cancel state
-	TestMode        bool   `json:"test_mode"`         // Is test subscription
-	TrialExpireTime int    `json:"trial_expire_time"` // Date of trial expire in Unixtime
-	UpdateTime      int    `json:"update_time"`       // Date of last change in Unixtime
+	CancelReason    string      `json:"cancel_reason"`     // Cancel reason
+	CreateTime      int         `json:"create_time"`       // Date of creation in Unixtime
+	ID              int         `json:"id"`                // Subscription ID
+	ItemID          string      `json:"item_id"`           // Subscription order item
+	NextBillTime    int         `json:"next_bill_time"`    // Date of next bill in Unixtime
+	Period          int         `json:"period"`            // Subscription period
+	PeriodStartTime int         `json:"period_start_time"` // Date of last period start in Unixtime
+	Price           int         `json:"price"`             // Subscription price
+	Status          string      `json:"status"`            // Subscription status
+	PendingCancel   BaseBoolInt `json:"pending_cancel"`    // Pending cancel state
+	TestMode        BaseBoolInt `json:"test_mode"`         // Is test subscription
+	TrialExpireTime int         `json:"trial_expire_time"` // Date of trial expire in Unixtime
+	UpdateTime      int         `json:"update_time"`       // Date of last change in Unixtime
 }

--- a/object/pages.go
+++ b/object/pages.go
@@ -16,21 +16,21 @@ type PagesWikipage struct {
 
 // PagesWikipageFull struct
 type PagesWikipageFull struct {
-	Created                  int    `json:"created"`                      // Date when the page has been created in Unixtime
-	CreatorID                int    `json:"creator_id"`                   // Page creator ID
-	CurrentUserCanEdit       int    `json:"current_user_can_edit"`        // Information whether current user can edit the page
-	CurrentUserCanEditAccess int    `json:"current_user_can_edit_access"` // Information whether current user can edit the page access settings
-	Edited                   int    `json:"edited"`                       // Date when the page has been edited in Unixtime
-	EditorID                 int    `json:"editor_id"`                    // Last editor ID
-	GroupID                  int    `json:"group_id"`                     // Community ID
-	HTML                     string `json:"html"`                         // Page content, HTML
-	ID                       int    `json:"id"`                           // Page ID
-	Source                   string `json:"source"`                       // Page content, wiki
-	Title                    string `json:"title"`                        // Page title
-	ViewURL                  string `json:"view_url"`                     // URL of the page preview
-	Views                    int    `json:"views"`                        // Views number
-	WhoCanEdit               int    `json:"who_can_edit"`                 // Edit settings of the page
-	WhoCanView               int    `json:"who_can_view"`                 // View settings of the page
+	Created                  int         `json:"created"`                      // Date when the page has been created in Unixtime
+	CreatorID                int         `json:"creator_id"`                   // Page creator ID
+	CurrentUserCanEdit       BaseBoolInt `json:"current_user_can_edit"`        // Information whether current user can edit the page
+	CurrentUserCanEditAccess BaseBoolInt `json:"current_user_can_edit_access"` // Information whether current user can edit the page access settings
+	Edited                   int         `json:"edited"`                       // Date when the page has been edited in Unixtime
+	EditorID                 int         `json:"editor_id"`                    // Last editor ID
+	GroupID                  int         `json:"group_id"`                     // Community ID
+	HTML                     string      `json:"html"`                         // Page content, HTML
+	ID                       int         `json:"id"`                           // Page ID
+	Source                   string      `json:"source"`                       // Page content, wiki
+	Title                    string      `json:"title"`                        // Page title
+	ViewURL                  string      `json:"view_url"`                     // URL of the page preview
+	Views                    int         `json:"views"`                        // Views number
+	WhoCanEdit               int         `json:"who_can_edit"`                 // Edit settings of the page
+	WhoCanView               int         `json:"who_can_view"`                 // View settings of the page
 }
 
 // PagesWikipageHistory struct

--- a/object/photos.go
+++ b/object/photos.go
@@ -19,8 +19,10 @@ type PhotosPhoto struct {
 	Text               string             `json:"text"`     // Photo caption
 	UserID             int                `json:"user_id"`  // ID of the user who have uploaded the photo
 	Width              int                `json:"width"`    // Original photo width
-	CanUpload          int                `json:"can_upload"`
-	CommentsDisabled   int                `json:"comments_disabled"`
+	CanUpload          BaseBoolInt        `json:"can_upload"`
+	CommentsDisabled   BaseBoolInt        `json:"comments_disabled"`
+	ThumbIsLast        BaseBoolInt        `json:"thumb_is_last"`
+	UploadByAdminsOnly BaseBoolInt        `json:"upload_by_admins_only"`
 	Created            int                `json:"created"`
 	Description        string             `json:"description"`
 	PrivacyComment     []string           `json:"privacy_comment"`
@@ -28,11 +30,9 @@ type PhotosPhoto struct {
 	Size               int                `json:"size"`
 	Sizes              []PhotosPhotoSizes `json:"sizes"`
 	ThumbID            int                `json:"thumb_id"`
-	ThumbIsLast        int                `json:"thumb_is_last"`
 	ThumbSrc           string             `json:"thumb_src"`
 	Title              string             `json:"title"`
 	Updated            int                `json:"updated"`
-	UploadByAdminsOnly int                `json:"upload_by_admins_only"`
 }
 
 // ToAttachment return attachment format
@@ -117,13 +117,13 @@ func (album PhotosPhotoAlbum) ToAttachment() string {
 
 // PhotosPhotoAlbumFull struct
 type PhotosPhotoAlbumFull struct {
-	CanUpload        int    `json:"can_upload"`        // Information whether current user can upload photo to the album
-	CommentsDisabled int    `json:"comments_disabled"` // Information whether album comments are disabled
-	Created          int    `json:"created"`           // Date when the album has been created in Unixtime
-	Description      string `json:"description"`       // Photo album description
-	ID               int    `json:"id"`                // Photo album ID
-	OwnerID          int    `json:"owner_id"`          // Album owner's ID
-	Size             int    `json:"size"`              // Photos number
+	CanUpload        BaseBoolInt `json:"can_upload"`        // Information whether current user can upload photo to the album
+	CommentsDisabled BaseBoolInt `json:"comments_disabled"` // Information whether album comments are disabled
+	Created          int         `json:"created"`           // Date when the album has been created in Unixtime
+	Description      string      `json:"description"`       // Photo album description
+	ID               int         `json:"id"`                // Photo album ID
+	OwnerID          int         `json:"owner_id"`          // Album owner's ID
+	Size             int         `json:"size"`              // Photos number
 	// TODO: PrivacyComment     interface{}           `json:"privacy_comment"`
 	// TODO: PrivacyView        interface{}           `json:"privacy_view"`
 	Sizes              []PhotosPhotoSizes `json:"sizes"`
@@ -144,7 +144,7 @@ func (album PhotosPhotoAlbumFull) ToAttachment() string {
 type PhotosPhotoFull struct {
 	AccessKey  string          `json:"access_key"`  // Access key for the photo
 	AlbumID    int             `json:"album_id"`    // Album ID
-	CanComment int             `json:"can_comment"` // Information whether current user can comment the photo
+	CanComment BaseBoolInt     `json:"can_comment"` // Information whether current user can comment the photo
 	Comments   BaseObjectCount `json:"comments"`
 	Date       int             `json:"date"`   // Date when uploaded
 	Height     int             `json:"height"` // Original photo height
@@ -171,7 +171,7 @@ func (photo PhotosPhotoFull) ToAttachment() string {
 type PhotosPhotoFullXtrRealOffset struct {
 	AccessKey  string             `json:"access_key"` // Access key for the photo
 	AlbumID    int                `json:"album_id"`   // Album ID
-	CanComment int                `json:"can_comment"`
+	CanComment BaseBoolInt        `json:"can_comment"`
 	Comments   BaseObjectCount    `json:"comments"`
 	Date       int                `json:"date"`   // Date when uploaded
 	Height     int                `json:"height"` // Original photo height
@@ -211,16 +211,16 @@ type PhotosPhotoSizes struct {
 
 // PhotosPhotoTag struct
 type PhotosPhotoTag struct {
-	Date       int     `json:"date"`        // Date when tag has been added in Unixtime
-	ID         int     `json:"id"`          // Tag ID
-	PlacerID   int     `json:"placer_id"`   // ID of the tag creator
-	TaggedName string  `json:"tagged_name"` // Tag description
-	UserID     int     `json:"user_id"`     // Tagged user ID
-	Viewed     int     `json:"viewed"`      // Information whether the tag is reviewed
-	X          float64 `json:"x"`           // Coordinate X of the left upper corner
-	X2         float64 `json:"x2"`          // Coordinate X of the right lower corner
-	Y          float64 `json:"y"`           // Coordinate Y of the left upper corner
-	Y2         float64 `json:"y2"`          // Coordinate Y of the right lower corner
+	Date       int         `json:"date"`        // Date when tag has been added in Unixtime
+	ID         int         `json:"id"`          // Tag ID
+	PlacerID   int         `json:"placer_id"`   // ID of the tag creator
+	TaggedName string      `json:"tagged_name"` // Tag description
+	UserID     int         `json:"user_id"`     // Tagged user ID
+	Viewed     BaseBoolInt `json:"viewed"`      // Information whether the tag is reviewed
+	X          float64     `json:"x"`           // Coordinate X of the left upper corner
+	X2         float64     `json:"x2"`          // Coordinate X of the right lower corner
+	Y          float64     `json:"y"`           // Coordinate Y of the left upper corner
+	Y2         float64     `json:"y2"`          // Coordinate Y of the right lower corner
 }
 
 // PhotosPhotoUpload struct

--- a/object/podcasts.go
+++ b/object/podcasts.go
@@ -24,9 +24,9 @@ type PodcastsEpisode struct {
 	LyricsID     int                 `json:"lyrics_id"`
 	NoSearch     int                 `json:"no_search"`
 	TrackCode    string              `json:"track_code"`
-	IsHq         bool                `json:"is_hq"`
-	IsFocusTrack bool                `json:"is_focus_track"`
-	IsExplicit   bool                `json:"is_explicit"`
+	IsHq         BaseBoolInt         `json:"is_hq"`
+	IsFocusTrack BaseBoolInt         `json:"is_focus_track"`
+	IsExplicit   BaseBoolInt         `json:"is_explicit"`
 	PodcastInfo  PodcastsPodcastInfo `json:"podcast_info"`
 }
 
@@ -35,8 +35,8 @@ type PodcastsPodcastInfo struct {
 	Cover struct {
 		Sizes []BaseImage `json:"cover"`
 	}
-	Plays       int    `json:"plays"`
-	IsFavorite  bool   `json:"is_favorite"`
-	Description string `json:"description"`
-	Position    int    `json:"position"`
+	Plays       int         `json:"plays"`
+	IsFavorite  BaseBoolInt `json:"is_favorite"`
+	Description string      `json:"description"`
+	Position    int         `json:"position"`
 }

--- a/object/polls.go
+++ b/object/polls.go
@@ -23,14 +23,14 @@ type PollsPoll struct {
 	Votes      int             `json:"votes"`    // Votes number
 	AnswerIDs  []int           `json:"answer_ids"`
 	EndDate    int             `json:"end_date"`
-	Anonymous  bool            `json:"anonymous"` // Information whether the pole is anonymous
-	Closed     bool            `json:"closed"`
-	IsBoard    bool            `json:"is_board"`
-	CanEdit    bool            `json:"can_edit"`
-	CanVote    bool            `json:"can_vote"`
-	CanReport  bool            `json:"can_report"`
-	CanShare   bool            `json:"can_share"`
-	Multiple   bool            `json:"multiple"`
+	Anonymous  BaseBoolInt     `json:"anonymous"` // Information whether the pole is anonymous
+	Closed     BaseBoolInt     `json:"closed"`
+	IsBoard    BaseBoolInt     `json:"is_board"`
+	CanEdit    BaseBoolInt     `json:"can_edit"`
+	CanVote    BaseBoolInt     `json:"can_vote"`
+	CanReport  BaseBoolInt     `json:"can_report"`
+	CanShare   BaseBoolInt     `json:"can_share"`
+	Multiple   BaseBoolInt     `json:"multiple"`
 	Photo      PhotosPhoto     `json:"photo"`
 	AuthorID   int             `json:"author_id"`
 	Background PollsBackground `json:"background"`

--- a/object/stories.go
+++ b/object/stories.go
@@ -31,23 +31,24 @@ type StoriesStoryStatsStat struct {
 
 // StoriesStory struct
 type StoriesStory struct {
-	AccessKey string `json:"access_key"` // Access key for private object.
-	ExpiresAt int    `json:"expires_at"` // Story expiration time. Unixtime.
-	CanHide   int    `json:"can_hide"`
+	AccessKey string      `json:"access_key"` // Access key for private object.
+	ExpiresAt int         `json:"expires_at"` // Story expiration time. Unixtime.
+	CanHide   BaseBoolInt `json:"can_hide"`
 	// Information whether story has question sticker and current user can send question to the author
-	CanAsk int `json:"can_ask"`
+	CanAsk BaseBoolInt `json:"can_ask"`
 	// Information whether story has question sticker and current user can send anonymous question to the author
-	CanAskAnonymous      int                      `json:"can_ask_anonymous"`
-	CanComment           int                      `json:"can_comment"`   // Information whether current user can comment the story (0 - no, 1 - yes).
-	CanReply             int                      `json:"can_reply"`     // Information whether current user can reply to the story (0 - no, 1 - yes).
-	CanSee               int                      `json:"can_see"`       // Information whether current user can see the story (0 - no, 1 - yes).
-	CanShare             int                      `json:"can_share"`     // Information whether current user can share the story (0 - no, 1 - yes).
+	CanAskAnonymous      BaseBoolInt              `json:"can_ask_anonymous"`
+	CanComment           BaseBoolInt              `json:"can_comment"`   // Information whether current user can comment the story (0 - no, 1 - yes).
+	CanReply             BaseBoolInt              `json:"can_reply"`     // Information whether current user can reply to the story (0 - no, 1 - yes).
+	CanSee               BaseBoolInt              `json:"can_see"`       // Information whether current user can see the story (0 - no, 1 - yes).
+	CanShare             BaseBoolInt              `json:"can_share"`     // Information whether current user can share the story (0 - no, 1 - yes).
 	Date                 int                      `json:"date"`          // Date when story has been added in Unixtime.
 	ID                   int                      `json:"id"`            // Story ID.
-	IsDeleted            bool                     `json:"is_deleted"`    // Information whether the story is deleted (false - no, true - yes).
-	IsExpired            bool                     `json:"is_expired"`    // Information whether the story is expired (false - no, true - yes).
-	NoSound              bool                     `json:"no_sound"`      // Is video without sound
-	IsRestricted         bool                     `json:"is_restricted"` // Does author have stories privacy restrictions
+	IsDeleted            BaseBoolInt              `json:"is_deleted"`    // Information whether the story is deleted (false - no, true - yes).
+	IsExpired            BaseBoolInt              `json:"is_expired"`    // Information whether the story is expired (false - no, true - yes).
+	NoSound              BaseBoolInt              `json:"no_sound"`      // Is video without sound
+	IsRestricted         BaseBoolInt              `json:"is_restricted"` // Does author have stories privacy restrictions
+	Seen                 BaseBoolInt              `json:"seen"`          // Information whether current user has seen the story or not (0 - no, 1 - yes).
 	Link                 StoriesStoryLink         `json:"link"`
 	OwnerID              int                      `json:"owner_id"` // Story owner's ID.
 	ParentStory          *StoriesStory            `json:"parent_story"`
@@ -56,7 +57,6 @@ type StoriesStory struct {
 	ParentStoryOwnerID   int                      `json:"parent_story_owner_id"`   // Parent story owner's ID.
 	Photo                PhotosPhoto              `json:"photo"`
 	Replies              StoriesReplies           `json:"replies"` // Replies to current story.
-	Seen                 int                      `json:"seen"`    // Information whether current user has seen the story or not (0 - no, 1 - yes).
 	Type                 string                   `json:"type"`
 	Video                VideoVideo               `json:"video"`
 	Views                int                      `json:"views"` // Views number.
@@ -91,10 +91,10 @@ type StoriesClickableSticker struct {
 	PlaceID int `json:"place_id"`
 
 	// type=question
-	Question               string `json:"question"`
-	QuestionButton         string `json:"question_button"`
-	QuestionDefaultPrivate bool   `json:"question_default_private"`
-	Color                  string `json:"color"`
+	Question               string      `json:"question"`
+	QuestionButton         string      `json:"question_button"`
+	QuestionDefaultPrivate BaseBoolInt `json:"question_default_private"`
+	Color                  string      `json:"color"`
 
 	// type=mention
 	Mention string `json:"mention,omitempty"`

--- a/object/users.go
+++ b/object/users.go
@@ -9,9 +9,6 @@ type UsersUser struct {
 	ID                     int               `json:"id"`
 	FirstName              string            `json:"first_name"`
 	LastName               string            `json:"last_name"`
-	IsClosed               bool              `json:"is_closed"`
-	CanAccessClosed        bool              `json:"can_access_closed"`
-	CanBeInvitedGroup      bool              `json:"can_be_invited_group"`
 	Sex                    int               `json:"sex"`
 	Nickname               string            `json:"nickname"`
 	Domain                 string            `json:"domain"`
@@ -27,18 +24,27 @@ type UsersUser struct {
 	Photo400Orig           string            `json:"photo_400_orig"`
 	PhotoMaxOrig           string            `json:"photo_max_orig"`
 	PhotoID                string            `json:"photo_id"`
-	HasPhoto               int               `json:"has_photo"`
-	HasMobile              int               `json:"has_mobile"`
-	IsFriend               int               `json:"is_friend"`
 	FriendStatus           int               `json:"friend_status"`
-	Online                 int               `json:"online"`
 	OnlineApp              int               `json:"online_app"`
-	OnlineMobile           int               `json:"online_mobile"`
-	CanPost                int               `json:"can_post"`
-	CanSeeAllPosts         int               `json:"can_see_all_posts"`
-	CanSeeAudio            int               `json:"can_see_audio"`
-	CanWritePrivateMessage int               `json:"can_write_private_message"`
-	CanSendFriendRequest   int               `json:"can_send_friend_request"`
+	Online                 BaseBoolInt       `json:"online"`
+	OnlineMobile           BaseBoolInt       `json:"online_mobile"`
+	HasPhoto               BaseBoolInt       `json:"has_photo"`
+	HasMobile              BaseBoolInt       `json:"has_mobile"`
+	IsClosed               BaseBoolInt       `json:"is_closed"`
+	IsFriend               BaseBoolInt       `json:"is_friend"`
+	IsFavorite             BaseBoolInt       `json:"is_favorite"`
+	IsHiddenFromFeed       BaseBoolInt       `json:"is_hidden_from_feed"`
+	CanAccessClosed        BaseBoolInt       `json:"can_access_closed"`
+	CanBeInvitedGroup      BaseBoolInt       `json:"can_be_invited_group"`
+	CanPost                BaseBoolInt       `json:"can_post"`
+	CanSeeAllPosts         BaseBoolInt       `json:"can_see_all_posts"`
+	CanSeeAudio            BaseBoolInt       `json:"can_see_audio"`
+	CanWritePrivateMessage BaseBoolInt       `json:"can_write_private_message"`
+	CanSendFriendRequest   BaseBoolInt       `json:"can_send_friend_request"`
+	Verified               BaseBoolInt       `json:"verified"`
+	Trending               BaseBoolInt       `json:"trending"`
+	Blacklisted            BaseBoolInt       `json:"blacklisted"`
+	BlacklistedByMe        BaseBoolInt       `json:"blacklisted_by_me"`
 	Facebook               string            `json:"facebook"`
 	FacebookName           string            `json:"facebook_name"`
 	Twitter                string            `json:"twitter"`
@@ -48,12 +54,7 @@ type UsersUser struct {
 	StatusAudio            AudioAudioFull    `json:"status_audio"`
 	LastSeen               UsersLastSeen     `json:"last_seen"`
 	CropPhoto              UsersCropPhoto    `json:"crop_photo"`
-	Verified               int               `json:"verified"`
 	FollowersCount         int               `json:"followers_count"`
-	Blacklisted            int               `json:"blacklisted"`
-	BlacklistedByMe        int               `json:"blacklisted_by_me"`
-	IsFavorite             int               `json:"is_favorite"`
-	IsHiddenFromFeed       int               `json:"is_hidden_from_feed"`
 	CommonCount            int               `json:"common_count"`
 	Occupation             UsersOccupation   `json:"occupation"`
 	Career                 []UsersCareer     `json:"career"`
@@ -81,7 +82,6 @@ type UsersUser struct {
 	Lists                  []int             `json:"lists"`
 	Deactivated            string            `json:"deactivated"`
 	WallDefault            string            `json:"wall_default"`
-	Trending               int               `json:"trending"`
 	Timezone               int               `json:"timezone"`
 	MaidenName             string            `json:"maiden_name"`
 	Exports                UsersExports      `json:"exports"`
@@ -100,10 +100,10 @@ func (user UsersUser) ToMention() string {
 
 // UsersOnlineInfo struct
 type UsersOnlineInfo struct {
-	AppID    int  `json:"app_id"`
-	Visible  bool `json:"visible"`
-	IsOnline bool `json:"is_online"`
-	IsMobile bool `json:"is_mobile"`
+	AppID    int         `json:"app_id"`
+	Visible  BaseBoolInt `json:"visible"`
+	IsOnline BaseBoolInt `json:"is_online"`
+	IsMobile BaseBoolInt `json:"is_mobile"`
 }
 
 // UsersUserMin struct

--- a/object/video.go
+++ b/object/video.go
@@ -8,22 +8,23 @@ import (
 type VideoVideo struct {
 	AccessKey      string            `json:"access_key"`       // Video access key
 	AddingDate     int               `json:"adding_date"`      // Date when the video has been added in Unixtime
-	CanAdd         int               `json:"can_add"`          // Information whether current user can add the video
-	CanAddToFaves  int               `json:"can_add_to_faves"` // Information whether current user can add the video to faves
-	CanComment     int               `json:"can_comment"`      // Information whether current user can comment the video
-	CanEdit        int               `json:"can_edit"`         // Information whether current user can edit the video
-	CanLike        int               `json:"can_like"`         // Information whether current user can like the video
-	CanRepost      int               `json:"can_repost"`       // Information whether current user can repost this video
-	Comments       int               `json:"comments"`         // Number of comments
-	Date           int               `json:"date"`             // Date when video has been uploaded in Unixtime
-	Description    string            `json:"description"`      // Video description
-	Duration       int               `json:"duration"`         // Video duration in seconds
+	CanAdd         BaseBoolInt       `json:"can_add"`          // Information whether current user can add the video
+	CanAddToFaves  BaseBoolInt       `json:"can_add_to_faves"` // Information whether current user can add the video to faves
+	CanComment     BaseBoolInt       `json:"can_comment"`      // Information whether current user can comment the video
+	CanEdit        BaseBoolInt       `json:"can_edit"`         // Information whether current user can edit the video
+	CanLike        BaseBoolInt       `json:"can_like"`         // Information whether current user can like the video
+	CanRepost      BaseBoolInt       `json:"can_repost"`       // Information whether current user can repost this video
+	IsFavorite     BaseBoolInt       `json:"is_favorite"`
+	IsPrivate      BaseBoolInt       `json:"is_private"`
+	Comments       int               `json:"comments"`    // Number of comments
+	Date           int               `json:"date"`        // Date when video has been uploaded in Unixtime
+	Description    string            `json:"description"` // Video description
+	Duration       int               `json:"duration"`    // Video duration in seconds
 	Files          VideoVideoFiles   `json:"files"`
 	FirstFrame     []VideoVideoImage `json:"first_frame"`
 	Image          []VideoVideoImage `json:"image"`
-	Height         int               `json:"height"` // Video height
-	ID             int               `json:"id"`     // Video ID
-	IsFavorite     bool              `json:"is_favorite"`
+	Height         int               `json:"height"`     // Video height
+	ID             int               `json:"id"`         // Video ID
 	Live           int               `json:"live"`       // Returns if the video is a live stream
 	OwnerID        int               `json:"owner_id"`   // Video owner ID
 	Photo130       string            `json:"photo_130"`  // URL of the preview image with 130 px in width
@@ -39,7 +40,6 @@ type VideoVideo struct {
 	Width          int               `json:"width"` // Video width
 	Platform       string            `json:"platform"`
 	LocalViews     int               `json:"local_views"`
-	IsPrivate      int               `json:"is_private"`
 	Likes          BaseLikesInfo     `json:"likes"`   // Count of likes
 	Reposts        BaseRepostsInfo   `json:"reposts"` // Count of views
 	PrivacyView    []interface{}     `json:"privacy_view"`
@@ -63,7 +63,7 @@ type VideoVideoFiles struct {
 
 // VideoCatBlock struct
 type VideoCatBlock struct {
-	CanHide int               `json:"can_hide"`
+	CanHide BaseBoolInt       `json:"can_hide"`
 	ID      int               `json:"id"`
 	Items   []VideoCatElement `json:"items"`
 	Name    string            `json:"name"`
@@ -74,25 +74,25 @@ type VideoCatBlock struct {
 
 // VideoCatElement struct
 type VideoCatElement struct {
-	CanAdd      int    `json:"can_add"`
-	CanEdit     int    `json:"can_edit"`
-	Comments    int    `json:"comments"`
-	Count       int    `json:"count"`
-	Date        int    `json:"date"`
-	Description string `json:"description"`
-	Duration    int    `json:"duration"`
-	ID          int    `json:"id"`
-	IsPrivate   int    `json:"is_private"`
-	OwnerID     int    `json:"owner_id"`
-	Photo130    string `json:"photo_130"`
-	Photo160    string `json:"photo_160"`
-	Photo320    string `json:"photo_320"`
-	Photo640    string `json:"photo_640"`
-	Photo800    string `json:"photo_800"`
-	Title       string `json:"title"`
-	Type        string `json:"type"`
-	UpdatedTime int    `json:"updated_time"`
-	Views       int    `json:"views"`
+	CanAdd      BaseBoolInt `json:"can_add"`
+	CanEdit     BaseBoolInt `json:"can_edit"`
+	IsPrivate   BaseBoolInt `json:"is_private"`
+	Comments    int         `json:"comments"`
+	Count       int         `json:"count"`
+	Date        int         `json:"date"`
+	Description string      `json:"description"`
+	Duration    int         `json:"duration"`
+	ID          int         `json:"id"`
+	OwnerID     int         `json:"owner_id"`
+	Photo130    string      `json:"photo_130"`
+	Photo160    string      `json:"photo_160"`
+	Photo320    string      `json:"photo_320"`
+	Photo640    string      `json:"photo_640"`
+	Photo800    string      `json:"photo_800"`
+	Title       string      `json:"title"`
+	Type        string      `json:"type"`
+	UpdatedTime int         `json:"updated_time"`
+	Views       int         `json:"views"`
 }
 
 // VideoSaveResult struct
@@ -123,7 +123,7 @@ type VideoVideoAlbumFull struct {
 	Count       int               `json:"count"`        // Total number of videos in album
 	ID          int               `json:"id"`           // Album ID
 	Image       []VideoVideoImage `json:"image"`        // Album cover image in different sizes
-	IsSystem    int               `json:"is_system"`    // Information whether album is system
+	IsSystem    BaseBoolInt       `json:"is_system"`    // Information whether album is system
 	OwnerID     int               `json:"owner_id"`     // Album owner's ID
 	Photo160    string            `json:"photo_160"`    // URL of the preview image with 160px in width
 	Photo320    string            `json:"photo_320"`    // URL of the preview image with 320px in width
@@ -136,10 +136,14 @@ type VideoVideoAlbumFull struct {
 type VideoVideoFull struct {
 	AccessKey     string            `json:"access_key"`  // Video access key
 	AddingDate    int               `json:"adding_date"` // Date when the video has been added in Unixtime
-	CanAdd        int               `json:"can_add"`     // Information whether current user can add the video
-	CanComment    int               `json:"can_comment"` // Information whether current user can comment the video
-	CanEdit       int               `json:"can_edit"`    // Information whether current user can edit the video
-	CanRepost     int               `json:"can_repost"`  // Information whether current user can comment the video
+	IsFavorite    BaseBoolInt       `json:"is_favorite"`
+	CanAdd        BaseBoolInt       `json:"can_add"`     // Information whether current user can add the video
+	CanComment    BaseBoolInt       `json:"can_comment"` // Information whether current user can comment the video
+	CanEdit       BaseBoolInt       `json:"can_edit"`    // Information whether current user can edit the video
+	CanRepost     BaseBoolInt       `json:"can_repost"`  // Information whether current user can comment the video
+	CanLike       BaseBoolInt       `json:"can_like"`
+	CanAddToFaves BaseBoolInt       `json:"can_add_to_faves"`
+	Repeat        BaseBoolInt       `json:"repeat"`      // Information whether the video is repeated
 	Comments      int               `json:"comments"`    // Number of comments
 	Date          int               `json:"date"`        // Date when video has been uploaded in Unixtime
 	Description   string            `json:"description"` // Video description
@@ -151,17 +155,13 @@ type VideoVideoFull struct {
 	OwnerID       int               `json:"owner_id"`   // Video owner ID
 	Player        string            `json:"player"`     // URL of the page with a player that can be used to play the video in the browser.
 	Processing    int               `json:"processing"` // Returns if the video is processing
-	Repeat        int               `json:"repeat"`     // Information whether the video is repeated
 	Title         string            `json:"title"`      // Video title
 	Views         int               `json:"views"`      // Number of views
 	Width         int               `json:"width"`
 	Height        int               `json:"height"`
 	Image         []VideoVideoImage `json:"image"`
-	IsFavorite    bool              `json:"is_favorite"`
 	FirstFrame    []VideoVideoImage `json:"first_frame"`
 	Added         int               `json:"added"`
-	CanLike       int               `json:"can_like"`
-	CanAddToFaves int               `json:"can_add_to_faves"`
 	Type          string            `json:"type"`
 	Reposts       BaseRepostsInfo   `json:"reposts"`
 }
@@ -173,20 +173,20 @@ func (video VideoVideoFull) ToAttachment() string {
 
 // VideoVideoTag struct
 type VideoVideoTag struct {
-	Date       int    `json:"date"`
-	ID         int    `json:"id"`
-	PlacerID   int    `json:"placer_id"`
-	TaggedName string `json:"tagged_name"`
-	UserID     int    `json:"user_id"`
-	Viewed     int    `json:"viewed"`
+	Date       int         `json:"date"`
+	ID         int         `json:"id"`
+	PlacerID   int         `json:"placer_id"`
+	TaggedName string      `json:"tagged_name"`
+	UserID     int         `json:"user_id"`
+	Viewed     BaseBoolInt `json:"viewed"`
 }
 
 // VideoVideoTagInfo struct
 type VideoVideoTagInfo struct {
 	AccessKey   string          `json:"access_key"`
 	AddingDate  int             `json:"adding_date"`
-	CanAdd      int             `json:"can_add"`
-	CanEdit     int             `json:"can_edit"`
+	CanAdd      BaseBoolInt     `json:"can_add"`
+	CanEdit     BaseBoolInt     `json:"can_edit"`
 	Comments    int             `json:"comments"`
 	Date        int             `json:"date"`
 	Description string          `json:"description"`
@@ -210,5 +210,5 @@ type VideoVideoTagInfo struct {
 // VideoVideoImage struct
 type VideoVideoImage struct {
 	BaseImage
-	WithPadding int `json:"with_padding"`
+	WithPadding BaseBoolInt `json:"with_padding"`
 }

--- a/object/wall.go
+++ b/object/wall.go
@@ -67,16 +67,16 @@ type WallViews struct {
 type WallWallCommentThread struct {
 	Count           int               `json:"count"` // Comments number
 	Items           []WallWallComment `json:"items"`
-	CanPost         bool              `json:"can_post"`        // Information whether current user can comment the post
-	GroupsCanPost   bool              `json:"groups_can_post"` // Information whether groups can comment the post
-	ShowReplyButton bool              `json:"show_reply_button"`
+	CanPost         BaseBoolInt       `json:"can_post"`        // Information whether current user can comment the post
+	GroupsCanPost   BaseBoolInt       `json:"groups_can_post"` // Information whether groups can comment the post
+	ShowReplyButton BaseBoolInt       `json:"show_reply_button"`
 }
 
 // WallWallComment struct
 type WallWallComment struct {
 	Attachments    []WallCommentAttachment `json:"attachments"`
 	Date           int                     `json:"date"` // Date when the comment has been added in Unixtime
-	Deleted        bool                    `json:"deleted"`
+	Deleted        BaseBoolInt             `json:"deleted"`
 	FromID         int                     `json:"from_id"` // Author ID
 	ID             int                     `json:"id"`      // Comment ID
 	Likes          BaseLikesInfo           `json:"likes"`
@@ -119,20 +119,20 @@ type WallWallpost struct {
 	Geo          BaseGeo                  `json:"geo"`
 	SignerID     int                      `json:"signer_id"` // Post signer ID
 	CopyHistory  []WallWallpost           `json:"copy_history"`
-	CanPin       int                      `json:"can_pin"`
-	CanDelete    int                      `json:"can_delete"`
-	CanEdit      int                      `json:"can_edit"`
-	IsPinned     int                      `json:"is_pinned"`
-	MarkedAsAds  int                      `json:"marked_as_ads"`
-	Edited       int                      `json:"edited"`      // Date of editing in Unixtime
-	IsFavorite   bool                     `json:"is_favorite"` // Information whether the post in favorites list
-	IsArchived   bool                     `json:"is_archived"` // Is post archived, only for post owners
+	CanPin       BaseBoolInt              `json:"can_pin"`
+	CanDelete    BaseBoolInt              `json:"can_delete"`
+	CanEdit      BaseBoolInt              `json:"can_edit"`
+	IsPinned     BaseBoolInt              `json:"is_pinned"`
+	IsFavorite   BaseBoolInt              `json:"is_favorite"` // Information whether the post in favorites list
+	IsArchived   BaseBoolInt              `json:"is_archived"` // Is post archived, only for post owners
+	MarkedAsAds  BaseBoolInt              `json:"marked_as_ads"`
+	Edited       int                      `json:"edited"` // Date of editing in Unixtime
 }
 
 // WallWallpostAttached struct
 type WallWallpostAttached struct {
 	Attachments []WallWallpostAttachment `json:"attachments"`
-	CanDelete   int                      `json:"can_delete"`
+	CanDelete   BaseBoolInt              `json:"can_delete"`
 	Comments    BaseCommentsInfo         `json:"comments"`
 	CopyOwnerID int                      `json:"copy_owner_id"`
 	CopyPostID  int                      `json:"copy_post_id"`
@@ -190,5 +190,5 @@ type WallWallpostToID struct {
 	SignerID    int                      `json:"signer_id"`   // Post signer ID
 	Text        string                   `json:"text"`        // Post text
 	ToID        int                      `json:"to_id"`       // Wall owner's ID
-	IsFavorite  bool                     `json:"is_favorite"` // Information whether the post in favorites list
+	IsFavorite  BaseBoolInt              `json:"is_favorite"` // Information whether the post in favorites list
 }

--- a/object/widgets.go
+++ b/object/widgets.go
@@ -10,10 +10,10 @@ type WidgetsCommentMedia struct {
 
 // WidgetsCommentReplies struct
 type WidgetsCommentReplies struct {
-	CanPost       int                         `json:"can_post"` // Information whether current user can comment the post
-	Count         int                         `json:"count"`    // Comments number
+	CanPost       BaseBoolInt                 `json:"can_post"` // Information whether current user can comment the post
+	GroupsCanPost BaseBoolInt                 `json:"groups_can_post"`
+	Count         int                         `json:"count"` // Comments number
 	Replies       []WidgetsCommentRepliesItem `json:"replies"`
-	GroupsCanPost bool                        `json:"groups_can_post"`
 }
 
 // WidgetsCommentRepliesItem struct
@@ -29,7 +29,8 @@ type WidgetsCommentRepliesItem struct {
 // WidgetsWidgetComment struct
 type WidgetsWidgetComment struct {
 	Attachments []WallCommentAttachment `json:"attachments"`
-	CanDelete   int                     `json:"can_delete"` // Information whether current user can delete the comment
+	CanDelete   BaseBoolInt             `json:"can_delete"` // Information whether current user can delete the comment
+	IsFavorite  BaseBoolInt             `json:"is_favorite"`
 	Comments    WidgetsCommentReplies   `json:"comments"`
 	Date        int                     `json:"date"`    // Date when the comment has been added in Unixtime
 	FromID      int                     `json:"from_id"` // Comment author ID
@@ -44,7 +45,6 @@ type WidgetsWidgetComment struct {
 	Views       struct {
 		Count int `json:"count"`
 	} `json:"views"`
-	IsFavorite bool `json:"is_favorite"`
 }
 
 // WidgetsWidgetLikes struct


### PR DESCRIPTION
BaseBoolInt is required to correctly parse API responses:
`int(0)`, `bool(false)` -> `BaseBoolInt(false)`
`int(1)`, `bool(true)` -> `BaseBoolInt(true)`