### PR TITLE
Фикс сериализатора для кнопок

### DIFF
--- a/object/messages.go
+++ b/object/messages.go
@@ -182,7 +182,7 @@ func (keyboard MessagesKeyboard) ToJSON() string {
 // MessagesKeyboardButton struct
 type MessagesKeyboardButton struct {
 	Action MessagesKeyboardButtonAction `json:"action"`
-	Color  string                       `json:"color"` // Button color
+	Color  string                       `json:"color,omitempty"` // Button color
 }
 
 // MessagesKeyboardButtonAction struct


### PR DESCRIPTION
Код для воспроизведения: 
```go
package main

import (
	"log"

	"github.com/SevereCloud/vksdk/api"
	"github.com/SevereCloud/vksdk/api/params"
	"github.com/SevereCloud/vksdk/object"
)

func buildKeyboard() object.MessagesKeyboard {
	keyboard := object.NewMessagesKeyboardInline()
	keyboard.AddRow()
	keyboard.AddOpenLinkButton("https://github.com/SevereCloud/vksdk", "Test Link", "")
	return keyboard
}

const token = "<YOUR_TOKEN>"
const peerID = 0 // user id to send

func main() {
	vk := api.Init(token)

	b := params.NewMessagesSendBuilder()
	b.Keyboard(buildKeyboard())
	b.PeerID(peerID)
        b.Message("test message")
	b.RandomID(0)

	_, err := vk.MessagesSend(b.Params)
	if err != nil {
		log.Fatal(err)
	}
}

```

Сейчас падает с 
```
Keyboard format is invalid: button [0][0] has action type which is not compatible with setting colors
```

Причина: в keyboard попадает пустой color, которго там быть вообще не должно