### PR TITLE
BREAKING CHANGE: support ...Params

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ func main() {
 	vk := api.NewVK(token)
 
 	// Получаем информацию о группе
-	group, err := vk.GroupsGetByID(api.Params{})
+	group, err := vk.GroupsGetByID(nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/api/README.md
+++ b/api/README.md
@@ -94,7 +94,7 @@ params := api.Params{
 }
 
 // Делаем запрос
-err = vk.RequestUnmarshal("users.get", params, &response)
+err = vk.RequestUnmarshal("users.get", &response, params)
 if err != nil {
 	log.Fatal(err)
 }

--- a/api/account.go
+++ b/api/account.go
@@ -8,7 +8,7 @@ import (
 //
 // https://vk.com/dev/account.ban
 func (vk *VK) AccountBan(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("account.ban", params, &response)
+	err = vk.RequestUnmarshal("account.ban", &response, params)
 	return
 }
 
@@ -21,7 +21,7 @@ type AccountChangePasswordResponse struct {
 //
 // https://vk.com/dev/account.changePassword
 func (vk *VK) AccountChangePassword(params Params) (response AccountChangePasswordResponse, err error) {
-	err = vk.RequestUnmarshal("account.changePassword", params, &response)
+	err = vk.RequestUnmarshal("account.changePassword", &response, params)
 	return
 }
 
@@ -37,7 +37,7 @@ type AccountGetActiveOffersResponse struct {
 //
 // https://vk.com/dev/account.getActiveOffers
 func (vk *VK) AccountGetActiveOffers(params Params) (response AccountGetActiveOffersResponse, err error) {
-	err = vk.RequestUnmarshal("account.getActiveOffers", params, &response)
+	err = vk.RequestUnmarshal("account.getActiveOffers", &response, params)
 	return
 }
 
@@ -45,7 +45,7 @@ func (vk *VK) AccountGetActiveOffers(params Params) (response AccountGetActiveOf
 //
 // https://vk.com/dev/account.getAppPermissions
 func (vk *VK) AccountGetAppPermissions(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("account.getAppPermissions", params, &response)
+	err = vk.RequestUnmarshal("account.getAppPermissions", &response, params)
 	return
 }
 
@@ -60,7 +60,7 @@ type AccountGetBannedResponse struct {
 //
 // https://vk.com/dev/account.getBanned
 func (vk *VK) AccountGetBanned(params Params) (response AccountGetBannedResponse, err error) {
-	err = vk.RequestUnmarshal("account.getBanned", params, &response)
+	err = vk.RequestUnmarshal("account.getBanned", &response, params)
 	return
 }
 
@@ -71,7 +71,7 @@ type AccountGetCountersResponse object.AccountAccountCounters
 //
 // https://vk.com/dev/account.getCounters
 func (vk *VK) AccountGetCounters(params Params) (response AccountGetCountersResponse, err error) {
-	err = vk.RequestUnmarshal("account.getCounters", params, &response)
+	err = vk.RequestUnmarshal("account.getCounters", &response, params)
 	return
 }
 
@@ -82,7 +82,7 @@ type AccountGetInfoResponse object.AccountInfo
 //
 // https://vk.com/dev/account.getInfo
 func (vk *VK) AccountGetInfo(params Params) (response AccountGetInfoResponse, err error) {
-	err = vk.RequestUnmarshal("account.getInfo", params, &response)
+	err = vk.RequestUnmarshal("account.getInfo", &response, params)
 	return
 }
 
@@ -93,7 +93,7 @@ type AccountGetProfileInfoResponse object.AccountUserSettings
 //
 // https://vk.com/dev/account.getProfileInfo
 func (vk *VK) AccountGetProfileInfo(params Params) (response AccountGetProfileInfoResponse, err error) {
-	err = vk.RequestUnmarshal("account.getProfileInfo", params, &response)
+	err = vk.RequestUnmarshal("account.getProfileInfo", &response, params)
 	return
 }
 
@@ -104,7 +104,7 @@ type AccountGetPushSettingsResponse object.AccountPushSettings
 //
 // https://vk.com/dev/account.getPushSettings
 func (vk *VK) AccountGetPushSettings(params Params) (response AccountGetPushSettingsResponse, err error) {
-	err = vk.RequestUnmarshal("account.getPushSettings", params, &response)
+	err = vk.RequestUnmarshal("account.getPushSettings", &response, params)
 	return
 }
 
@@ -112,7 +112,7 @@ func (vk *VK) AccountGetPushSettings(params Params) (response AccountGetPushSett
 //
 // https://vk.com/dev/account.registerDevice
 func (vk *VK) AccountRegisterDevice(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("account.registerDevice", params, &response)
+	err = vk.RequestUnmarshal("account.registerDevice", &response, params)
 	return
 }
 
@@ -126,7 +126,7 @@ type AccountSaveProfileInfoResponse struct {
 //
 // https://vk.com/dev/account.saveProfileInfo
 func (vk *VK) AccountSaveProfileInfo(params Params) (response AccountSaveProfileInfoResponse, err error) {
-	err = vk.RequestUnmarshal("account.saveProfileInfo", params, &response)
+	err = vk.RequestUnmarshal("account.saveProfileInfo", &response, params)
 	return
 }
 
@@ -134,7 +134,7 @@ func (vk *VK) AccountSaveProfileInfo(params Params) (response AccountSaveProfile
 //
 // https://vk.com/dev/account.setInfo
 func (vk *VK) AccountSetInfo(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("account.setInfo", params, &response)
+	err = vk.RequestUnmarshal("account.setInfo", &response, params)
 	return
 }
 
@@ -143,7 +143,7 @@ func (vk *VK) AccountSetInfo(params Params) (response int, err error) {
 //
 // https://vk.com/dev/account.setNameInMenu
 func (vk *VK) AccountSetNameInMenu(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("account.setNameInMenu", params, &response)
+	err = vk.RequestUnmarshal("account.setNameInMenu", &response, params)
 	return
 }
 
@@ -151,7 +151,7 @@ func (vk *VK) AccountSetNameInMenu(params Params) (response int, err error) {
 //
 // https://vk.com/dev/account.setOffline
 func (vk *VK) AccountSetOffline(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("account.setOffline", params, &response)
+	err = vk.RequestUnmarshal("account.setOffline", &response, params)
 	return
 }
 
@@ -159,7 +159,7 @@ func (vk *VK) AccountSetOffline(params Params) (response int, err error) {
 //
 // https://vk.com/dev/account.setOnline
 func (vk *VK) AccountSetOnline(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("account.setOnline", params, &response)
+	err = vk.RequestUnmarshal("account.setOnline", &response, params)
 	return
 }
 
@@ -167,7 +167,7 @@ func (vk *VK) AccountSetOnline(params Params) (response int, err error) {
 //
 // https://vk.com/dev/account.setPushSettings
 func (vk *VK) AccountSetPushSettings(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("account.setPushSettings", params, &response)
+	err = vk.RequestUnmarshal("account.setPushSettings", &response, params)
 	return
 }
 
@@ -175,7 +175,7 @@ func (vk *VK) AccountSetPushSettings(params Params) (response int, err error) {
 //
 // https://vk.com/dev/account.setSilenceMode
 func (vk *VK) AccountSetSilenceMode(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("account.setSilenceMode", params, &response)
+	err = vk.RequestUnmarshal("account.setSilenceMode", &response, params)
 	return
 }
 
@@ -183,7 +183,7 @@ func (vk *VK) AccountSetSilenceMode(params Params) (response int, err error) {
 //
 // https://vk.com/dev/account.unban
 func (vk *VK) AccountUnban(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("account.unban", params, &response)
+	err = vk.RequestUnmarshal("account.unban", &response, params)
 	return
 }
 
@@ -191,6 +191,6 @@ func (vk *VK) AccountUnban(params Params) (response int, err error) {
 //
 // https://vk.com/dev/account.unregisterDevice
 func (vk *VK) AccountUnregisterDevice(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("account.unregisterDevice", params, &response)
+	err = vk.RequestUnmarshal("account.unregisterDevice", &response, params)
 	return
 }

--- a/api/account_test.go
+++ b/api/account_test.go
@@ -27,7 +27,7 @@ func TestVK_AccountBan(t *testing.T) {
 
 	time.Sleep(3 * time.Second)
 
-	res, err := vkUser.AccountGetBanned(api.Params{})
+	res, err := vkUser.AccountGetBanned(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.Count)
 	assert.NotEmpty(t, res.Items)
@@ -56,7 +56,7 @@ func TestVK_AccountGetActiveOffers(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.AccountGetActiveOffers(api.Params{})
+	_, err := vkUser.AccountGetActiveOffers(nil)
 	noError(t, err)
 }
 
@@ -88,7 +88,7 @@ func TestVK_AccountGetInfo(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.AccountGetInfo(api.Params{})
+	_, err := vkUser.AccountGetInfo(nil)
 	noError(t, err)
 }
 
@@ -97,7 +97,7 @@ func TestVK_AccountGetProfileInfo(t *testing.T) {
 
 	needUserToken(t)
 
-	info, err := vkUser.AccountGetProfileInfo(api.Params{})
+	info, err := vkUser.AccountGetProfileInfo(nil)
 	noError(t, err)
 	assert.NotEmpty(t, info.FirstName)
 	assert.NotEmpty(t, info.LastName)
@@ -133,7 +133,7 @@ func TestVK_AccountSaveProfileInfo(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.AccountSaveProfileInfo(api.Params{})
+	_, err := vkUser.AccountSaveProfileInfo(nil)
 	noError(t, err)
 }
 
@@ -150,7 +150,7 @@ func TestVK_AccountSetOffline(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.AccountSetOffline(api.Params{})
+	_, err := vkUser.AccountSetOffline(nil)
 	noError(t, err)
 }
 
@@ -159,7 +159,7 @@ func TestVK_AccountSetOnline(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.AccountSetOnline(api.Params{})
+	_, err := vkUser.AccountSetOnline(nil)
 	noError(t, err)
 }
 

--- a/api/ads.go
+++ b/api/ads.go
@@ -11,7 +11,7 @@ import (
 //
 // https://vk.com/dev/ads.addOfficeUsers
 // func (vk *VK) AdsAddOfficeUsers(params Params) (response AdsAddOfficeUsersResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.addOfficeUsers", params, &response)
+// 	err = vk.RequestUnmarshal("ads.addOfficeUsers", &response, params)
 // 	return
 // }
 
@@ -22,7 +22,7 @@ import (
 //
 // https://vk.com/dev/ads.checkLink
 // func (vk *VK) AdsCheckLink(params Params) (response AdsCheckLinkResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.checkLink", params, &response)
+// 	err = vk.RequestUnmarshal("ads.checkLink", &response, params)
 // 	return
 // }
 
@@ -33,7 +33,7 @@ import (
 //
 // https://vk.com/dev/ads.createAds
 // func (vk *VK) AdsCreateAds(params Params) (response AdsCreateAdsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.createAds", params, &response)
+// 	err = vk.RequestUnmarshal("ads.createAds", &response, params)
 // 	return
 // }
 
@@ -44,7 +44,7 @@ import (
 //
 // https://vk.com/dev/ads.createCampaigns
 // func (vk *VK) AdsCreateCampaigns(params Params) (response AdsCreateCampaignsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.createCampaigns", params, &response)
+// 	err = vk.RequestUnmarshal("ads.createCampaigns", &response, params)
 // 	return
 // }
 
@@ -55,7 +55,7 @@ import (
 //
 // https://vk.com/dev/ads.createClients
 // func (vk *VK) AdsCreateClients(params Params) (response AdsCreateClientsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.createClients", params, &response)
+// 	err = vk.RequestUnmarshal("ads.createClients", &response, params)
 // 	return
 // }
 
@@ -66,7 +66,7 @@ import (
 //
 // https://vk.com/dev/ads.createLookalikeRequest
 // func (vk *VK) AdsCreateLookalikeRequest(params Params) (response AdsCreateLookalikeRequestResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.createLookalikeRequest", params, &response)
+// 	err = vk.RequestUnmarshal("ads.createLookalikeRequest", &response, params)
 // 	return
 // }
 
@@ -77,7 +77,7 @@ import (
 //
 // https://vk.com/dev/ads.createTargetGroup
 // func (vk *VK) AdsCreateTargetGroup(params Params) (response AdsCreateTargetGroupResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.createTargetGroup", params, &response)
+// 	err = vk.RequestUnmarshal("ads.createTargetGroup", &response, params)
 // 	return
 // }
 
@@ -88,7 +88,7 @@ import (
 //
 // https://vk.com/dev/ads.createTargetPixel
 // func (vk *VK) AdsCreateTargetPixel(params Params) (response AdsCreateTargetPixelResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.createTargetPixel", params, &response)
+// 	err = vk.RequestUnmarshal("ads.createTargetPixel", &response, params)
 // 	return
 // }
 
@@ -99,7 +99,7 @@ import (
 //
 // https://vk.com/dev/ads.deleteAds
 // func (vk *VK) AdsDeleteAds(params Params) (response AdsDeleteAdsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.deleteAds", params, &response)
+// 	err = vk.RequestUnmarshal("ads.deleteAds", &response, params)
 // 	return
 // }
 
@@ -110,7 +110,7 @@ import (
 //
 // https://vk.com/dev/ads.deleteCampaigns
 // func (vk *VK) AdsDeleteCampaigns(params Params) (response AdsDeleteCampaignsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.deleteCampaigns", params, &response)
+// 	err = vk.RequestUnmarshal("ads.deleteCampaigns", &response, params)
 // 	return
 // }
 
@@ -121,7 +121,7 @@ import (
 //
 // https://vk.com/dev/ads.deleteClients
 // func (vk *VK) AdsDeleteClients(params Params) (response AdsDeleteClientsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.deleteClients", params, &response)
+// 	err = vk.RequestUnmarshal("ads.deleteClients", &response, params)
 // 	return
 // }
 
@@ -129,7 +129,7 @@ import (
 //
 // https://vk.com/dev/ads.deleteTargetGroup
 func (vk *VK) AdsDeleteTargetGroup(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("ads.deleteTargetGroup", params, &response)
+	err = vk.RequestUnmarshal("ads.deleteTargetGroup", &response, params)
 	return
 }
 
@@ -137,7 +137,7 @@ func (vk *VK) AdsDeleteTargetGroup(params Params) (response int, err error) {
 //
 // https://vk.com/dev/ads.deleteTargetPixel
 func (vk *VK) AdsDeleteTargetPixel(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("ads.deleteTargetPixel", params, &response)
+	err = vk.RequestUnmarshal("ads.deleteTargetPixel", &response, params)
 	return
 }
 
@@ -148,7 +148,7 @@ type AdsGetAccountsResponse []object.AdsAccount
 //
 // https://vk.com/dev/ads.getAccounts
 func (vk *VK) AdsGetAccounts(params Params) (response AdsGetAccountsResponse, err error) {
-	err = vk.RequestUnmarshal("ads.getAccounts", params, &response)
+	err = vk.RequestUnmarshal("ads.getAccounts", &response, params)
 	return
 }
 
@@ -159,7 +159,7 @@ func (vk *VK) AdsGetAccounts(params Params) (response AdsGetAccountsResponse, er
 //
 // https://vk.com/dev/ads.getAds
 // func (vk *VK) AdsGetAds(params Params) (response AdsGetAdsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getAds", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getAds", &response, params)
 // 	return
 // }
 
@@ -170,7 +170,7 @@ func (vk *VK) AdsGetAccounts(params Params) (response AdsGetAccountsResponse, er
 //
 // https://vk.com/dev/ads.getAdsLayout
 // func (vk *VK) AdsGetAdsLayout(params Params) (response AdsGetAdsLayoutResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getAdsLayout", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getAdsLayout", &response, params)
 // 	return
 // }
 
@@ -181,7 +181,7 @@ func (vk *VK) AdsGetAccounts(params Params) (response AdsGetAccountsResponse, er
 //
 // https://vk.com/dev/ads.getAdsTargeting
 // func (vk *VK) AdsGetAdsTargeting(params Params) (response AdsGetAdsTargetingResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getAdsTargeting", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getAdsTargeting", &response, params)
 // 	return
 // }
 
@@ -192,7 +192,7 @@ func (vk *VK) AdsGetAccounts(params Params) (response AdsGetAccountsResponse, er
 //
 // https://vk.com/dev/ads.getBudget
 // func (vk *VK) AdsGetBudget(params Params) (response AdsGetBudgetResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getBudget", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getBudget", &response, params)
 // 	return
 // }
 
@@ -203,7 +203,7 @@ func (vk *VK) AdsGetAccounts(params Params) (response AdsGetAccountsResponse, er
 //
 // https://vk.com/dev/ads.getCampaigns
 // func (vk *VK) AdsGetCampaigns(params Params) (response AdsGetCampaignsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getCampaigns", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getCampaigns", &response, params)
 // 	return
 // }
 
@@ -214,7 +214,7 @@ func (vk *VK) AdsGetAccounts(params Params) (response AdsGetAccountsResponse, er
 //
 // https://vk.com/dev/ads.getCategories
 // func (vk *VK) AdsGetCategories(params Params) (response AdsGetCategoriesResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getCategories", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getCategories", &response, params)
 // 	return
 // }
 
@@ -225,7 +225,7 @@ func (vk *VK) AdsGetAccounts(params Params) (response AdsGetAccountsResponse, er
 //
 // https://vk.com/dev/ads.getClients
 // func (vk *VK) AdsGetClients(params Params) (response AdsGetClientsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getClients", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getClients", &response, params)
 // 	return
 // }
 
@@ -236,7 +236,7 @@ func (vk *VK) AdsGetAccounts(params Params) (response AdsGetAccountsResponse, er
 //
 // https://vk.com/dev/ads.getDemographics
 // func (vk *VK) AdsGetDemographics(params Params) (response AdsGetDemographicsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getDemographics", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getDemographics", &response, params)
 // 	return
 // }
 
@@ -247,7 +247,7 @@ func (vk *VK) AdsGetAccounts(params Params) (response AdsGetAccountsResponse, er
 //
 // https://vk.com/dev/ads.getFloodStats
 // func (vk *VK) AdsGetFloodStats(params Params) (response AdsGetFloodStatsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getFloodStats", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getFloodStats", &response, params)
 // 	return
 // }
 
@@ -258,7 +258,7 @@ func (vk *VK) AdsGetAccounts(params Params) (response AdsGetAccountsResponse, er
 //
 // https://vk.com/dev/ads.getLookalikeRequests
 // func (vk *VK) AdsGetLookalikeRequests(params Params) (response AdsGetLookalikeRequestsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getLookalikeRequests", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getLookalikeRequests", &response, params)
 // 	return
 // }
 
@@ -271,7 +271,7 @@ type AdsGetMusiciansResponse struct {
 //
 // https://vk.com/dev/ads.getMusicians
 func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, err error) {
-	err = vk.RequestUnmarshal("ads.getMusicians", params, &response)
+	err = vk.RequestUnmarshal("ads.getMusicians", &response, params)
 	return
 }
 
@@ -282,7 +282,7 @@ func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, 
 //
 // https://vk.com/dev/ads.getOfficeUsers
 // func (vk *VK) AdsGetOfficeUsers(params Params) (response AdsGetOfficeUsersResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getOfficeUsers", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getOfficeUsers", &response, params)
 // 	return
 // }
 
@@ -293,7 +293,7 @@ func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, 
 //
 // https://vk.com/dev/ads.getPostsReach
 // func (vk *VK) AdsGetPostsReach(params Params) (response AdsGetPostsReachResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getPostsReach", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getPostsReach", &response, params)
 // 	return
 // }
 
@@ -304,7 +304,7 @@ func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, 
 //
 // https://vk.com/dev/ads.getRejectionReason
 // func (vk *VK) AdsGetRejectionReason(params Params) (response AdsGetRejectionReasonResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getRejectionReason", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getRejectionReason", &response, params)
 // 	return
 // }
 
@@ -315,7 +315,7 @@ func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, 
 //
 // https://vk.com/dev/ads.getStatistics
 // func (vk *VK) AdsGetStatistics(params Params) (response AdsGetStatisticsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getStatistics", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getStatistics", &response, params)
 // 	return
 // }
 
@@ -326,7 +326,7 @@ func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, 
 //
 // https://vk.com/dev/ads.getSuggestions
 // func (vk *VK) AdsGetSuggestions(params Params) (response AdsGetSuggestionsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getSuggestions", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getSuggestions", &response, params)
 // 	return
 // }
 
@@ -337,7 +337,7 @@ func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, 
 //
 // https://vk.com/dev/ads.getTargetGroups
 // func (vk *VK) AdsGetTargetGroups(params Params) (response AdsGetTargetGroupsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getTargetGroups", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getTargetGroups", &response, params)
 // 	return
 // }
 
@@ -348,7 +348,7 @@ func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, 
 //
 // https://vk.com/dev/ads.getTargetPixels
 // func (vk *VK) AdsGetTargetPixels(params Params) (response AdsGetTargetPixelsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getTargetPixels", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getTargetPixels", &response, params)
 // 	return
 // }
 
@@ -359,7 +359,7 @@ func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, 
 //
 // https://vk.com/dev/ads.getTargetingStats
 // func (vk *VK) AdsGetTargetingStats(params Params) (response AdsGetTargetingStatsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getTargetingStats", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getTargetingStats", &response, params)
 // 	return
 // }
 
@@ -370,7 +370,7 @@ func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, 
 //
 // https://vk.com/dev/ads.getUploadURL
 // func (vk *VK) AdsGetUploadURL(params Params) (response AdsGetUploadURLResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getUploadURL", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getUploadURL", &response, params)
 // 	return
 // }
 
@@ -381,7 +381,7 @@ func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, 
 //
 // https://vk.com/dev/ads.getVideoUploadURL
 // func (vk *VK) AdsGetVideoUploadURL(params Params) (response AdsGetVideoUploadURLResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.getVideoUploadURL", params, &response)
+// 	err = vk.RequestUnmarshal("ads.getVideoUploadURL", &response, params)
 // 	return
 // }
 
@@ -392,7 +392,7 @@ func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, 
 //
 // https://vk.com/dev/ads.importTargetContacts
 // func (vk *VK) AdsImportTargetContacts(params Params) (response AdsImportTargetContactsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.importTargetContacts", params, &response)
+// 	err = vk.RequestUnmarshal("ads.importTargetContacts", &response, params)
 // 	return
 // }
 
@@ -403,7 +403,7 @@ func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, 
 //
 // https://vk.com/dev/ads.removeOfficeUsers
 // func (vk *VK) AdsRemoveOfficeUsers(params Params) (response AdsRemoveOfficeUsersResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.removeOfficeUsers", params, &response)
+// 	err = vk.RequestUnmarshal("ads.removeOfficeUsers", &response, params)
 // 	return
 // }
 
@@ -417,7 +417,7 @@ func (vk *VK) AdsGetMusicians(params Params) (response AdsGetMusiciansResponse, 
 //
 // https://vk.com/dev/ads.removeTargetContacts
 func (vk *VK) AdsRemoveTargetContacts(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("ads.removeTargetContacts", params, &response)
+	err = vk.RequestUnmarshal("ads.removeTargetContacts", &response, params)
 	return
 }
 
@@ -431,7 +431,7 @@ func (vk *VK) AdsRemoveTargetContacts(params Params) (response int, err error) {
 // 		response AdsSaveLookalikeRequestResultResponse,
 // 		err error,
 // 	) {
-// 	err = vk.RequestUnmarshal("ads.saveLookalikeRequestResult", params, &response)
+// 	err = vk.RequestUnmarshal("ads.saveLookalikeRequestResult", &response, params)
 // 	return
 // }
 
@@ -442,7 +442,7 @@ func (vk *VK) AdsRemoveTargetContacts(params Params) (response int, err error) {
 //
 // https://vk.com/dev/ads.shareTargetGroup
 // func (vk *VK) AdsShareTargetGroup(params Params) (response AdsShareTargetGroupResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.shareTargetGroup", params, &response)
+// 	err = vk.RequestUnmarshal("ads.shareTargetGroup", &response, params)
 // 	return
 // }
 
@@ -453,7 +453,7 @@ func (vk *VK) AdsRemoveTargetContacts(params Params) (response int, err error) {
 //
 // https://vk.com/dev/ads.updateAds
 // func (vk *VK) AdsUpdateAds(params Params) (response AdsUpdateAdsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.updateAds", params, &response)
+// 	err = vk.RequestUnmarshal("ads.updateAds", &response, params)
 // 	return
 // }
 
@@ -464,7 +464,7 @@ func (vk *VK) AdsRemoveTargetContacts(params Params) (response int, err error) {
 //
 // https://vk.com/dev/ads.updateCampaigns
 // func (vk *VK) AdsUpdateCampaigns(params Params) (response AdsUpdateCampaignsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.updateCampaigns", params, &response)
+// 	err = vk.RequestUnmarshal("ads.updateCampaigns", &response, params)
 // 	return
 // }
 
@@ -475,7 +475,7 @@ func (vk *VK) AdsRemoveTargetContacts(params Params) (response int, err error) {
 //
 // https://vk.com/dev/ads.updateClients
 // func (vk *VK) AdsUpdateClients(params Params) (response AdsUpdateClientsResponse, err error) {
-// 	err = vk.RequestUnmarshal("ads.updateClients", params, &response)
+// 	err = vk.RequestUnmarshal("ads.updateClients", &response, params)
 // 	return
 // }
 
@@ -483,7 +483,7 @@ func (vk *VK) AdsRemoveTargetContacts(params Params) (response int, err error) {
 //
 // https://vk.com/dev/ads.updateTargetGroup
 func (vk *VK) AdsUpdateTargetGroup(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("ads.updateTargetGroup", params, &response)
+	err = vk.RequestUnmarshal("ads.updateTargetGroup", &response, params)
 	return
 }
 
@@ -491,6 +491,6 @@ func (vk *VK) AdsUpdateTargetGroup(params Params) (response int, err error) {
 //
 // https://vk.com/dev/ads.updateTargetPixel
 func (vk *VK) AdsUpdateTargetPixel(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("ads. updateTargetPixel", params, &response)
+	err = vk.RequestUnmarshal("ads. updateTargetPixel", &response, params)
 	return
 }

--- a/api/ads_test.go
+++ b/api/ads_test.go
@@ -12,7 +12,7 @@ func TestVK_AdsGetAccounts(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.AdsGetAccounts(api.Params{})
+	_, err := vkUser.AdsGetAccounts(nil)
 	noError(t, err)
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -106,7 +106,7 @@ var (
 func TestMain(m *testing.M) {
 	vkGroup = api.NewVK(os.Getenv("GROUP_TOKEN"))
 	if vkGroup.AccessToken != "" {
-		group, err := vkGroup.GroupsGetByID(api.Params{})
+		group, err := vkGroup.GroupsGetByID(nil)
 		if err != nil {
 			log.Fatalf("GROUP_TOKEN bad: %v", err)
 		}
@@ -121,7 +121,7 @@ func TestMain(m *testing.M) {
 	vkUser.Limit = api.LimitUserToken
 
 	if vkUser.AccessToken != "" {
-		user, err := vkUser.UsersGet(api.Params{})
+		user, err := vkUser.UsersGet(nil)
 		if err != nil {
 			log.Fatalf("USER_TOKEN bad: %v", err)
 		}
@@ -144,7 +144,7 @@ func TestVK_Request(t *testing.T) {
 	vk := api.NewVK(groupToken)
 
 	t.Run("Request 403 error", func(t *testing.T) {
-		_, err := vk.Request("", api.Params{})
+		_, err := vk.Request("", nil)
 		if err == nil {
 			t.Errorf("VK.Request() got1 = %v, want -1", err)
 		}
@@ -171,7 +171,7 @@ func TestVK_RequestLimit(t *testing.T) {
 		wg.Add(1)
 
 		go func() {
-			_, err := vkUser.UsersGet(api.Params{})
+			_, err := vkUser.UsersGet(nil)
 			assert.NoError(t, err)
 
 			wg.Done()
@@ -190,7 +190,7 @@ func TestVK_InvalidContentType(t *testing.T) {
 
 	var testObj string
 
-	err := vkGroup.RequestUnmarshal("t/t", api.Params{}, testObj)
+	err := vkGroup.RequestUnmarshal("t/t", testObj, nil)
 	if err == nil || err.Error() != "api: invalid content-type" {
 		t.Errorf("VK.RequestUnmarshal() error = %v", err)
 	}

--- a/api/apps.go
+++ b/api/apps.go
@@ -8,7 +8,7 @@ import (
 //
 // https://vk.com/dev/apps.deleteAppRequests
 func (vk *VK) AppsDeleteAppRequests(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("apps.deleteAppRequests", params, &response)
+	err = vk.RequestUnmarshal("apps.deleteAppRequests", &response, params)
 	return
 }
 
@@ -23,7 +23,7 @@ type AppsGetResponse struct {
 //
 // https://vk.com/dev/apps.get
 func (vk *VK) AppsGet(params Params) (response AppsGetResponse, err error) {
-	err = vk.RequestUnmarshal("apps.get", params, &response)
+	err = vk.RequestUnmarshal("apps.get", &response, params)
 	return
 }
 
@@ -38,7 +38,7 @@ type AppsGetCatalogResponse struct {
 //
 // https://vk.com/dev/apps.getCatalog
 func (vk *VK) AppsGetCatalog(params Params) (response AppsGetCatalogResponse, err error) {
-	err = vk.RequestUnmarshal("apps.getCatalog", params, &response)
+	err = vk.RequestUnmarshal("apps.getCatalog", &response, params)
 	return
 }
 
@@ -54,8 +54,7 @@ type AppsGetFriendsListResponse struct {
 //
 // https://vk.com/dev/apps.getFriendsList
 func (vk *VK) AppsGetFriendsList(params Params) (response AppsGetFriendsListResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("apps.getFriendsList", params, &response)
+	err = vk.RequestUnmarshal("apps.getFriendsList", &response, params, Params{"extended": false})
 
 	return
 }
@@ -72,8 +71,7 @@ type AppsGetFriendsListExtendedResponse struct {
 //
 // https://vk.com/dev/apps.getFriendsList
 func (vk *VK) AppsGetFriendsListExtended(params Params) (response AppsGetFriendsListExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("apps.getFriendsList", params, &response)
+	err = vk.RequestUnmarshal("apps.getFriendsList", &response, params, Params{"extended": true})
 
 	return
 }
@@ -90,8 +88,7 @@ type AppsGetLeaderboardResponse struct {
 //
 // https://vk.com/dev/apps.getLeaderboard
 func (vk *VK) AppsGetLeaderboard(params Params) (response AppsGetLeaderboardResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("apps.getLeaderboard", params, &response)
+	err = vk.RequestUnmarshal("apps.getLeaderboard", &response, params, Params{"extended": false})
 
 	return
 }
@@ -112,8 +109,7 @@ type AppsGetLeaderboardExtendedResponse struct {
 //
 // https://vk.com/dev/apps.getLeaderboard
 func (vk *VK) AppsGetLeaderboardExtended(params Params) (response AppsGetLeaderboardExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("apps.getLeaderboard", params, &response)
+	err = vk.RequestUnmarshal("apps.getLeaderboard", &response, params, Params{"extended": true})
 
 	return
 }
@@ -130,7 +126,7 @@ type AppsGetScopesResponse struct {
 //
 // https://vk.com/dev/apps.getScopes
 func (vk *VK) AppsGetScopes(params Params) (response AppsGetScopesResponse, err error) {
-	err = vk.RequestUnmarshal("apps.getScopes", params, &response)
+	err = vk.RequestUnmarshal("apps.getScopes", &response, params)
 	return
 }
 
@@ -140,7 +136,7 @@ func (vk *VK) AppsGetScopes(params Params) (response AppsGetScopesResponse, err 
 //
 // https://vk.com/dev/apps.getScore
 func (vk *VK) AppsGetScore(params Params) (response string, err error) {
-	err = vk.RequestUnmarshal("apps.getScore", params, &response)
+	err = vk.RequestUnmarshal("apps.getScore", &response, params)
 	return
 }
 
@@ -148,6 +144,6 @@ func (vk *VK) AppsGetScore(params Params) (response string, err error) {
 //
 // https://vk.com/dev/apps.sendRequest
 func (vk *VK) AppsSendRequest(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("apps.sendRequest", params, &response)
+	err = vk.RequestUnmarshal("apps.sendRequest", &response, params)
 	return
 }

--- a/api/apps_test.go
+++ b/api/apps_test.go
@@ -13,7 +13,7 @@ func TestVK_AppsDeleteAppRequests(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.AppsDeleteAppRequests(api.Params{})
+	res, err := vkUser.AppsDeleteAppRequests(nil)
 	noError(t, err)
 	assert.Equal(t, res, 1)
 }
@@ -54,7 +54,7 @@ func TestVK_AppsGetCatalog(t *testing.T) {
 
 	needServiceToken(t)
 
-	res, err := vkService.AppsGetCatalog(api.Params{})
+	res, err := vkService.AppsGetCatalog(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.Count)
 	assert.NotEmpty(t, res.Items)
@@ -65,12 +65,12 @@ func TestVK_AppsGetFriendsList(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.AppsGetFriendsList(api.Params{})
+	_, err := vkUser.AppsGetFriendsList(nil)
 	noError(t, err)
 	// assert.NotEmpty(t, res.Count)
 	// assert.NotEmpty(t, res.Items)
 
-	_, err = vkUser.AppsGetFriendsListExtended(api.Params{})
+	_, err = vkUser.AppsGetFriendsListExtended(nil)
 	noError(t, err)
 }
 
@@ -81,7 +81,7 @@ func TestVK_AppsGetScopes(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.AppsGetScopes(api.Params{})
+	res, err := vkUser.AppsGetScopes(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.Count)
 

--- a/api/appwidgets.go
+++ b/api/appwidgets.go
@@ -17,7 +17,7 @@ func (vk *VK) AppWidgetsGetAppImageUploadServer(params Params) (
 	response AppWidgetsGetAppImageUploadServerResponse,
 	err error,
 ) {
-	err = vk.RequestUnmarshal("appWidgets.getAppImageUploadServer", params, &response)
+	err = vk.RequestUnmarshal("appWidgets.getAppImageUploadServer", &response, params)
 	return
 }
 
@@ -31,7 +31,7 @@ type AppWidgetsGetAppImagesResponse struct {
 //
 // https://vk.com/dev/appWidgets.getAppImages
 func (vk *VK) AppWidgetsGetAppImages(params Params) (response AppWidgetsGetAppImagesResponse, err error) {
-	err = vk.RequestUnmarshal("appWidgets.getAppImages", params, &response)
+	err = vk.RequestUnmarshal("appWidgets.getAppImages", &response, params)
 	return
 }
 
@@ -48,7 +48,7 @@ func (vk *VK) AppWidgetsGetGroupImageUploadServer(params Params) (
 	response AppWidgetsGetGroupImageUploadServerResponse,
 	err error,
 ) {
-	err = vk.RequestUnmarshal("appWidgets.getGroupImageUploadServer", params, &response)
+	err = vk.RequestUnmarshal("appWidgets.getGroupImageUploadServer", &response, params)
 	return
 }
 
@@ -62,7 +62,7 @@ type AppWidgetsGetGroupImagesResponse struct {
 //
 // https://vk.com/dev/appWidgets.getGroupImages
 func (vk *VK) AppWidgetsGetGroupImages(params Params) (response AppWidgetsGetGroupImagesResponse, err error) {
-	err = vk.RequestUnmarshal("appWidgets.getGroupImages", params, &response)
+	err = vk.RequestUnmarshal("appWidgets.getGroupImages", &response, params)
 	return
 }
 
@@ -70,7 +70,7 @@ func (vk *VK) AppWidgetsGetGroupImages(params Params) (response AppWidgetsGetGro
 //
 // https://vk.com/dev/appWidgets.getImagesById
 func (vk *VK) AppWidgetsGetImagesByID(params Params) (response object.AppWidgetsImage, err error) {
-	err = vk.RequestUnmarshal("appWidgets.getImagesById", params, &response)
+	err = vk.RequestUnmarshal("appWidgets.getImagesById", &response, params)
 	return
 }
 
@@ -78,7 +78,7 @@ func (vk *VK) AppWidgetsGetImagesByID(params Params) (response object.AppWidgets
 //
 // https://vk.com/dev/appWidgets.saveAppImage
 func (vk *VK) AppWidgetsSaveAppImage(params Params) (response object.AppWidgetsImage, err error) {
-	err = vk.RequestUnmarshal("appWidgets.saveAppImage", params, &response)
+	err = vk.RequestUnmarshal("appWidgets.saveAppImage", &response, params)
 	return
 }
 
@@ -86,7 +86,7 @@ func (vk *VK) AppWidgetsSaveAppImage(params Params) (response object.AppWidgetsI
 //
 // https://vk.com/dev/appWidgets.saveGroupImage
 func (vk *VK) AppWidgetsSaveGroupImage(params Params) (response object.AppWidgetsImage, err error) {
-	err = vk.RequestUnmarshal("appWidgets.saveGroupImage", params, &response)
+	err = vk.RequestUnmarshal("appWidgets.saveGroupImage", &response, params)
 	return
 }
 
@@ -94,7 +94,7 @@ func (vk *VK) AppWidgetsSaveGroupImage(params Params) (response object.AppWidget
 //
 // https://vk.com/dev/appWidgets.update
 func (vk *VK) AppWidgetsUpdate(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("appWidgets.update", params, &response)
+	err = vk.RequestUnmarshal("appWidgets.update", &response, params)
 
 	return
 }

--- a/api/auth.go
+++ b/api/auth.go
@@ -4,7 +4,7 @@ package api // import "github.com/SevereCloud/vksdk/api"
 //
 // https://vk.com/dev/auth.checkPhone
 func (vk *VK) AuthCheckPhone(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("auth.checkPhone", params, &response)
+	err = vk.RequestUnmarshal("auth.checkPhone", &response, params)
 	return
 }
 
@@ -18,6 +18,6 @@ type AuthRestoreResponse struct {
 //
 // https://vk.com/dev/auth.restore
 func (vk *VK) AuthRestore(params Params) (response AuthRestoreResponse, err error) {
-	err = vk.RequestUnmarshal("auth.restore", params, &response)
+	err = vk.RequestUnmarshal("auth.restore", &response, params)
 	return
 }

--- a/api/board.go
+++ b/api/board.go
@@ -8,7 +8,7 @@ import (
 //
 // https://vk.com/dev/board.addTopic
 func (vk *VK) BoardAddTopic(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("board.addTopic", params, &response)
+	err = vk.RequestUnmarshal("board.addTopic", &response, params)
 	return
 }
 
@@ -16,7 +16,7 @@ func (vk *VK) BoardAddTopic(params Params) (response int, err error) {
 //
 // https://vk.com/dev/board.closeTopic
 func (vk *VK) BoardCloseTopic(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("board.closeTopic", params, &response)
+	err = vk.RequestUnmarshal("board.closeTopic", &response, params)
 	return
 }
 
@@ -24,7 +24,7 @@ func (vk *VK) BoardCloseTopic(params Params) (response int, err error) {
 //
 // https://vk.com/dev/board.createComment
 func (vk *VK) BoardCreateComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("board.createComment", params, &response)
+	err = vk.RequestUnmarshal("board.createComment", &response, params)
 	return
 }
 
@@ -32,7 +32,7 @@ func (vk *VK) BoardCreateComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/board.deleteComment
 func (vk *VK) BoardDeleteComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("board.deleteComment", params, &response)
+	err = vk.RequestUnmarshal("board.deleteComment", &response, params)
 	return
 }
 
@@ -40,7 +40,7 @@ func (vk *VK) BoardDeleteComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/board.deleteTopic
 func (vk *VK) BoardDeleteTopic(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("board.deleteTopic", params, &response)
+	err = vk.RequestUnmarshal("board.deleteTopic", &response, params)
 	return
 }
 
@@ -48,7 +48,7 @@ func (vk *VK) BoardDeleteTopic(params Params) (response int, err error) {
 //
 // https://vk.com/dev/board.editComment
 func (vk *VK) BoardEditComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("board.editComment", params, &response)
+	err = vk.RequestUnmarshal("board.editComment", &response, params)
 	return
 }
 
@@ -56,7 +56,7 @@ func (vk *VK) BoardEditComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/board.editTopic
 func (vk *VK) BoardEditTopic(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("board.editTopic", params, &response)
+	err = vk.RequestUnmarshal("board.editTopic", &response, params)
 	return
 }
 
@@ -64,7 +64,7 @@ func (vk *VK) BoardEditTopic(params Params) (response int, err error) {
 //
 // https://vk.com/dev/board.fixTopic
 func (vk *VK) BoardFixTopic(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("board.fixTopic", params, &response)
+	err = vk.RequestUnmarshal("board.fixTopic", &response, params)
 	return
 }
 
@@ -82,8 +82,7 @@ type BoardGetCommentsResponse struct {
 //
 // https://vk.com/dev/board.getComments
 func (vk *VK) BoardGetComments(params Params) (response BoardGetCommentsResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("board.getComments", params, &response)
+	err = vk.RequestUnmarshal("board.getComments", &response, params, Params{"extended": false})
 
 	return
 }
@@ -104,8 +103,7 @@ type BoardGetCommentsExtendedResponse struct {
 //
 // https://vk.com/dev/board.getComments
 func (vk *VK) BoardGetCommentsExtended(params Params) (response BoardGetCommentsExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("board.getComments", params, &response)
+	err = vk.RequestUnmarshal("board.getComments", &response, params, Params{"extended": true})
 
 	return
 }
@@ -124,8 +122,7 @@ type BoardGetTopicsResponse struct {
 //
 // https://vk.com/dev/board.getTopics
 func (vk *VK) BoardGetTopics(params Params) (response BoardGetTopicsResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("board.getTopics", params, &response)
+	err = vk.RequestUnmarshal("board.getTopics", &response, params, Params{"extended": false})
 
 	return
 }
@@ -146,8 +143,7 @@ type BoardGetTopicsExtendedResponse struct {
 //
 // https://vk.com/dev/board.getTopics
 func (vk *VK) BoardGetTopicsExtended(params Params) (response BoardGetTopicsExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("board.getTopics", params, &response)
+	err = vk.RequestUnmarshal("board.getTopics", &response, params, Params{"extended": true})
 
 	return
 }
@@ -156,7 +152,7 @@ func (vk *VK) BoardGetTopicsExtended(params Params) (response BoardGetTopicsExte
 //
 // https://vk.com/dev/board.openTopic
 func (vk *VK) BoardOpenTopic(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("board.openTopic", params, &response)
+	err = vk.RequestUnmarshal("board.openTopic", &response, params)
 	return
 }
 
@@ -164,7 +160,7 @@ func (vk *VK) BoardOpenTopic(params Params) (response int, err error) {
 //
 // https://vk.com/dev/board.restoreComment
 func (vk *VK) BoardRestoreComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("board.restoreComment", params, &response)
+	err = vk.RequestUnmarshal("board.restoreComment", &response, params)
 	return
 }
 
@@ -172,6 +168,6 @@ func (vk *VK) BoardRestoreComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/board.unfixTopic
 func (vk *VK) BoardUnfixTopic(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("board.unfixTopic", params, &response)
+	err = vk.RequestUnmarshal("board.unfixTopic", &response, params)
 	return
 }

--- a/api/captcha.go
+++ b/api/captcha.go
@@ -2,6 +2,6 @@ package api
 
 // CaptchaForce api method.
 func (vk *VK) CaptchaForce(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("captcha.force", params, &response)
+	err = vk.RequestUnmarshal("captcha.force", &response, params)
 	return
 }

--- a/api/captcha_test.go
+++ b/api/captcha_test.go
@@ -12,7 +12,7 @@ func TestVK_CaptchaForce(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.CaptchaForce(api.Params{})
+	_, err := vkUser.CaptchaForce(nil)
 
 	if !errors.Is(err, api.ErrCaptcha) {
 		t.Errorf("VK.CaptchaForce() err=%v, want 14", err)

--- a/api/database.go
+++ b/api/database.go
@@ -14,7 +14,7 @@ type DatabaseGetChairsResponse struct {
 //
 // https://vk.com/dev/database.getChairs
 func (vk *VK) DatabaseGetChairs(params Params) (response DatabaseGetChairsResponse, err error) {
-	err = vk.RequestUnmarshal("database.getChairs", params, &response)
+	err = vk.RequestUnmarshal("database.getChairs", &response, params)
 	return
 }
 
@@ -28,7 +28,7 @@ type DatabaseGetCitiesResponse struct {
 //
 // https://vk.com/dev/database.getCities
 func (vk *VK) DatabaseGetCities(params Params) (response DatabaseGetCitiesResponse, err error) {
-	err = vk.RequestUnmarshal("database.getCities", params, &response)
+	err = vk.RequestUnmarshal("database.getCities", &response, params)
 	return
 }
 
@@ -39,7 +39,7 @@ type DatabaseGetCitiesByIDResponse []object.DatabaseCity
 //
 // https://vk.com/dev/database.getCitiesByID
 func (vk *VK) DatabaseGetCitiesByID(params Params) (response DatabaseGetCitiesByIDResponse, err error) {
-	err = vk.RequestUnmarshal("database.getCitiesById", params, &response)
+	err = vk.RequestUnmarshal("database.getCitiesById", &response, params)
 	return
 }
 
@@ -53,7 +53,7 @@ type DatabaseGetCountriesResponse struct {
 //
 // https://vk.com/dev/database.getCountries
 func (vk *VK) DatabaseGetCountries(params Params) (response DatabaseGetCountriesResponse, err error) {
-	err = vk.RequestUnmarshal("database.getCountries", params, &response)
+	err = vk.RequestUnmarshal("database.getCountries", &response, params)
 	return
 }
 
@@ -64,7 +64,7 @@ type DatabaseGetCountriesByIDResponse []object.BaseObject
 //
 // https://vk.com/dev/database.getCountriesByID
 func (vk *VK) DatabaseGetCountriesByID(params Params) (response DatabaseGetCountriesByIDResponse, err error) {
-	err = vk.RequestUnmarshal("database.getCountriesById", params, &response)
+	err = vk.RequestUnmarshal("database.getCountriesById", &response, params)
 	return
 }
 
@@ -78,7 +78,7 @@ type DatabaseGetFacultiesResponse struct {
 //
 // https://vk.com/dev/database.getFaculties
 func (vk *VK) DatabaseGetFaculties(params Params) (response DatabaseGetFacultiesResponse, err error) {
-	err = vk.RequestUnmarshal("database.getFaculties", params, &response)
+	err = vk.RequestUnmarshal("database.getFaculties", &response, params)
 	return
 }
 
@@ -92,7 +92,7 @@ type DatabaseGetMetroStationsResponse struct {
 //
 // https://vk.com/dev/database.getMetroStations
 func (vk *VK) DatabaseGetMetroStations(params Params) (response DatabaseGetMetroStationsResponse, err error) {
-	err = vk.RequestUnmarshal("database.getMetroStations", params, &response)
+	err = vk.RequestUnmarshal("database.getMetroStations", &response, params)
 	return
 }
 
@@ -103,7 +103,7 @@ type DatabaseGetMetroStationsByIDResponse []object.DatabaseMetroStation
 //
 // https://vk.com/dev/database.getMetroStationsById
 func (vk *VK) DatabaseGetMetroStationsByID(params Params) (response DatabaseGetMetroStationsByIDResponse, err error) {
-	err = vk.RequestUnmarshal("database.getMetroStationsById", params, &response)
+	err = vk.RequestUnmarshal("database.getMetroStationsById", &response, params)
 	return
 }
 
@@ -117,7 +117,7 @@ type DatabaseGetRegionsResponse struct {
 //
 // https://vk.com/dev/database.getRegions
 func (vk *VK) DatabaseGetRegions(params Params) (response DatabaseGetRegionsResponse, err error) {
-	err = vk.RequestUnmarshal("database.getRegions", params, &response)
+	err = vk.RequestUnmarshal("database.getRegions", &response, params)
 	return
 }
 
@@ -130,7 +130,7 @@ type DatabaseGetSchoolClassesResponse [][]interface{}
 //
 // https://vk.com/dev/database.getSchoolClasses
 func (vk *VK) DatabaseGetSchoolClasses(params Params) (response DatabaseGetSchoolClassesResponse, err error) {
-	err = vk.RequestUnmarshal("database.getSchoolClasses", params, &response)
+	err = vk.RequestUnmarshal("database.getSchoolClasses", &response, params)
 	return
 }
 
@@ -144,7 +144,7 @@ type DatabaseGetSchoolsResponse struct {
 //
 // https://vk.com/dev/database.getSchools
 func (vk *VK) DatabaseGetSchools(params Params) (response DatabaseGetSchoolsResponse, err error) {
-	err = vk.RequestUnmarshal("database.getSchools", params, &response)
+	err = vk.RequestUnmarshal("database.getSchools", &response, params)
 	return
 }
 
@@ -158,6 +158,6 @@ type DatabaseGetUniversitiesResponse struct {
 //
 // https://vk.com/dev/database.getUniversities
 func (vk *VK) DatabaseGetUniversities(params Params) (response DatabaseGetUniversitiesResponse, err error) {
-	err = vk.RequestUnmarshal("database.getUniversities", params, &response)
+	err = vk.RequestUnmarshal("database.getUniversities", &response, params)
 	return
 }

--- a/api/database_test.go
+++ b/api/database_test.go
@@ -67,7 +67,7 @@ func TestVK_DatabaseGetCountries(t *testing.T) {
 
 	needServiceToken(t)
 
-	res, err := vkService.DatabaseGetCountries(api.Params{})
+	res, err := vkService.DatabaseGetCountries(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.Count)
 

--- a/api/docs.go
+++ b/api/docs.go
@@ -8,7 +8,7 @@ import (
 //
 // https://vk.com/dev/docs.add
 func (vk *VK) DocsAdd(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("docs.add", params, &response)
+	err = vk.RequestUnmarshal("docs.add", &response, params)
 	return
 }
 
@@ -16,7 +16,7 @@ func (vk *VK) DocsAdd(params Params) (response int, err error) {
 //
 // https://vk.com/dev/docs.delete
 func (vk *VK) DocsDelete(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("docs.delete", params, &response)
+	err = vk.RequestUnmarshal("docs.delete", &response, params)
 	return
 }
 
@@ -24,7 +24,7 @@ func (vk *VK) DocsDelete(params Params) (response int, err error) {
 //
 // https://vk.com/dev/docs.edit
 func (vk *VK) DocsEdit(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("docs.edit", params, &response)
+	err = vk.RequestUnmarshal("docs.edit", &response, params)
 	return
 }
 
@@ -38,7 +38,7 @@ type DocsGetResponse struct {
 //
 // https://vk.com/dev/docs.get
 func (vk *VK) DocsGet(params Params) (response DocsGetResponse, err error) {
-	err = vk.RequestUnmarshal("docs.get", params, &response)
+	err = vk.RequestUnmarshal("docs.get", &response, params)
 	return
 }
 
@@ -49,7 +49,7 @@ type DocsGetByIDResponse []object.DocsDoc
 //
 // https://vk.com/dev/docs.getById
 func (vk *VK) DocsGetByID(params Params) (response DocsGetByIDResponse, err error) {
-	err = vk.RequestUnmarshal("docs.getById", params, &response)
+	err = vk.RequestUnmarshal("docs.getById", &response, params)
 	return
 }
 
@@ -62,7 +62,7 @@ type DocsGetMessagesUploadServerResponse struct {
 //
 // https://vk.com/dev/docs.getMessagesUploadServer
 func (vk *VK) DocsGetMessagesUploadServer(params Params) (response DocsGetMessagesUploadServerResponse, err error) {
-	err = vk.RequestUnmarshal("docs.getMessagesUploadServer", params, &response)
+	err = vk.RequestUnmarshal("docs.getMessagesUploadServer", &response, params)
 	return
 }
 
@@ -76,7 +76,7 @@ type DocsGetTypesResponse struct {
 //
 // https://vk.com/dev/docs.getTypes
 func (vk *VK) DocsGetTypes(params Params) (response DocsGetTypesResponse, err error) {
-	err = vk.RequestUnmarshal("docs.getTypes", params, &response)
+	err = vk.RequestUnmarshal("docs.getTypes", &response, params)
 	return
 }
 
@@ -89,7 +89,7 @@ type DocsGetUploadServerResponse struct {
 //
 // https://vk.com/dev/docs.getUploadServer
 func (vk *VK) DocsGetUploadServer(params Params) (response DocsGetUploadServerResponse, err error) {
-	err = vk.RequestUnmarshal("docs.getUploadServer", params, &response)
+	err = vk.RequestUnmarshal("docs.getUploadServer", &response, params)
 	return
 }
 
@@ -102,7 +102,7 @@ type DocsGetWallUploadServerResponse struct {
 //
 // https://vk.com/dev/docs.getWallUploadServer
 func (vk *VK) DocsGetWallUploadServer(params Params) (response DocsGetWallUploadServerResponse, err error) {
-	err = vk.RequestUnmarshal("docs.getWallUploadServer", params, &response)
+	err = vk.RequestUnmarshal("docs.getWallUploadServer", &response, params)
 	return
 }
 
@@ -118,7 +118,7 @@ type DocsSaveResponse struct {
 //
 // https://vk.com/dev/docs.save
 func (vk *VK) DocsSave(params Params) (response DocsSaveResponse, err error) {
-	err = vk.RequestUnmarshal("docs.save", params, &response)
+	err = vk.RequestUnmarshal("docs.save", &response, params)
 	return
 }
 
@@ -132,6 +132,6 @@ type DocsSearchResponse struct {
 //
 // https://vk.com/dev/docs.search
 func (vk *VK) DocsSearch(params Params) (response DocsSearchResponse, err error) {
-	err = vk.RequestUnmarshal("docs.search", params, &response)
+	err = vk.RequestUnmarshal("docs.search", &response, params)
 	return
 }

--- a/api/docs_test.go
+++ b/api/docs_test.go
@@ -101,7 +101,7 @@ func TestVK_DocsGetTypes(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.DocsGetTypes(api.Params{})
+	res, err := vkUser.DocsGetTypes(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.Count)
 
@@ -117,7 +117,7 @@ func TestVK_DocsGetUploadServer(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.DocsGetUploadServer(api.Params{})
+	res, err := vkUser.DocsGetUploadServer(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.UploadURL)
 }
@@ -127,7 +127,7 @@ func TestVK_DocsGetMessagesUploadServer(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.DocsGetMessagesUploadServer(api.Params{})
+	res, err := vkUser.DocsGetMessagesUploadServer(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.UploadURL)
 }
@@ -137,7 +137,7 @@ func TestVK_DocsGetWallUploadServer(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.DocsGetWallUploadServer(api.Params{})
+	res, err := vkUser.DocsGetWallUploadServer(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.UploadURL)
 }

--- a/api/downloadedGames.go
+++ b/api/downloadedGames.go
@@ -13,8 +13,7 @@ type DownloadedGamesGetPaidStatusResponse struct {
 //
 // https://vk.com/dev/downloadedGames.getPaidStatus
 func (vk *VK) DownloadedGamesGetPaidStatus(params Params) (response DownloadedGamesGetPaidStatusResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("downloadedGames.getPaidStatus", params, &response)
+	err = vk.RequestUnmarshal("downloadedGames.getPaidStatus", &response, params, Params{"extended": false})
 
 	return
 }

--- a/api/execute.go
+++ b/api/execute.go
@@ -18,16 +18,13 @@ func (vk *VK) ExecuteWithArgs(code string, params Params, obj interface{}) error
 		token = vk.tokenPool.Get()
 	}
 
-	copyParams := make(Params)
-	for key, value := range params {
-		copyParams[key] = FmtValue(value, 0)
+	reqParams := Params{
+		"code":         code,
+		"access_token": token,
+		"v":            vk.Version,
 	}
 
-	copyParams["code"] = code
-	copyParams["access_token"] = token
-	copyParams["v"] = vk.Version
-
-	resp, err := vk.Handler("execute", copyParams)
+	resp, err := vk.Handler("execute", params, reqParams)
 
 	jsonErr := json.Unmarshal(resp.Response, &obj)
 	if jsonErr != nil {

--- a/api/fave.go
+++ b/api/fave.go
@@ -8,7 +8,7 @@ import (
 //
 // https://vk.com/dev/fave.addArticle
 func (vk *VK) FaveAddArticle(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.addArticle", params, &response)
+	err = vk.RequestUnmarshal("fave.addArticle", &response, params)
 	return
 }
 
@@ -16,7 +16,7 @@ func (vk *VK) FaveAddArticle(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.addLink
 func (vk *VK) FaveAddLink(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.addLink", params, &response)
+	err = vk.RequestUnmarshal("fave.addLink", &response, params)
 	return
 }
 
@@ -24,7 +24,7 @@ func (vk *VK) FaveAddLink(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.addPage
 func (vk *VK) FaveAddPage(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.addPage", params, &response)
+	err = vk.RequestUnmarshal("fave.addPage", &response, params)
 	return
 }
 
@@ -32,7 +32,7 @@ func (vk *VK) FaveAddPage(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.addPost
 func (vk *VK) FaveAddPost(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.addPost", params, &response)
+	err = vk.RequestUnmarshal("fave.addPost", &response, params)
 	return
 }
 
@@ -40,7 +40,7 @@ func (vk *VK) FaveAddPost(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.addProduct
 func (vk *VK) FaveAddProduct(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.addProduct", params, &response)
+	err = vk.RequestUnmarshal("fave.addProduct", &response, params)
 	return
 }
 
@@ -51,7 +51,7 @@ type FaveAddTagResponse object.FaveTag
 //
 // https://vk.com/dev/fave.addTag
 func (vk *VK) FaveAddTag(params Params) (response FaveAddTagResponse, err error) {
-	err = vk.RequestUnmarshal("fave.addTag", params, &response)
+	err = vk.RequestUnmarshal("fave.addTag", &response, params)
 	return
 }
 
@@ -59,7 +59,7 @@ func (vk *VK) FaveAddTag(params Params) (response FaveAddTagResponse, err error)
 //
 // https://vk.com/dev/fave.addVideo
 func (vk *VK) FaveAddVideo(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.addVideo", params, &response)
+	err = vk.RequestUnmarshal("fave.addVideo", &response, params)
 	return
 }
 
@@ -67,7 +67,7 @@ func (vk *VK) FaveAddVideo(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.editTag
 func (vk *VK) FaveEditTag(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.editTag", params, &response)
+	err = vk.RequestUnmarshal("fave.editTag", &response, params)
 	return
 }
 
@@ -83,8 +83,7 @@ type FaveGetResponse struct {
 //
 // https://vk.com/dev/fave.get
 func (vk *VK) FaveGet(params Params) (response FaveGetResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("fave.get", params, &response)
+	err = vk.RequestUnmarshal("fave.get", &response, params, Params{"extended": false})
 
 	return
 }
@@ -102,8 +101,7 @@ type FaveGetExtendedResponse struct {
 //
 // https://vk.com/dev/fave.get
 func (vk *VK) FaveGetExtended(params Params) (response FaveGetExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("fave.get", params, &response)
+	err = vk.RequestUnmarshal("fave.get", &response, params, Params{"extended": true})
 
 	return
 }
@@ -118,7 +116,7 @@ type FaveGetPagesResponse struct {
 //
 // https://vk.com/dev/fave.getPages
 func (vk *VK) FaveGetPages(params Params) (response FaveGetPagesResponse, err error) {
-	err = vk.RequestUnmarshal("fave.getPages", params, &response)
+	err = vk.RequestUnmarshal("fave.getPages", &response, params)
 	return
 }
 
@@ -132,7 +130,7 @@ type FaveGetTagsResponse struct {
 //
 // https://vk.com/dev/fave.getTags
 func (vk *VK) FaveGetTags(params Params) (response FaveGetTagsResponse, err error) {
-	err = vk.RequestUnmarshal("fave.getTags", params, &response)
+	err = vk.RequestUnmarshal("fave.getTags", &response, params)
 	return
 }
 
@@ -140,7 +138,7 @@ func (vk *VK) FaveGetTags(params Params) (response FaveGetTagsResponse, err erro
 //
 // https://vk.com/dev/fave.markSeen
 func (vk *VK) FaveMarkSeen(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.markSeen", params, &response)
+	err = vk.RequestUnmarshal("fave.markSeen", &response, params)
 	return
 }
 
@@ -148,7 +146,7 @@ func (vk *VK) FaveMarkSeen(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.removeArticle
 func (vk *VK) FaveRemoveArticle(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.removeArticle", params, &response)
+	err = vk.RequestUnmarshal("fave.removeArticle", &response, params)
 	return
 }
 
@@ -156,7 +154,7 @@ func (vk *VK) FaveRemoveArticle(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.removeLink
 func (vk *VK) FaveRemoveLink(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.removeLink", params, &response)
+	err = vk.RequestUnmarshal("fave.removeLink", &response, params)
 	return
 }
 
@@ -164,7 +162,7 @@ func (vk *VK) FaveRemoveLink(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.removePage
 func (vk *VK) FaveRemovePage(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.removePage", params, &response)
+	err = vk.RequestUnmarshal("fave.removePage", &response, params)
 	return
 }
 
@@ -172,7 +170,7 @@ func (vk *VK) FaveRemovePage(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.removePost
 func (vk *VK) FaveRemovePost(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.removePost", params, &response)
+	err = vk.RequestUnmarshal("fave.removePost", &response, params)
 	return
 }
 
@@ -180,7 +178,7 @@ func (vk *VK) FaveRemovePost(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.removeProduct
 func (vk *VK) FaveRemoveProduct(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.removeProduct", params, &response)
+	err = vk.RequestUnmarshal("fave.removeProduct", &response, params)
 	return
 }
 
@@ -188,7 +186,7 @@ func (vk *VK) FaveRemoveProduct(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.removeTag
 func (vk *VK) FaveRemoveTag(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.removeTag", params, &response)
+	err = vk.RequestUnmarshal("fave.removeTag", &response, params)
 	return
 }
 
@@ -196,7 +194,7 @@ func (vk *VK) FaveRemoveTag(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.removeVideo
 func (vk *VK) FaveRemoveVideo(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.removeVideo", params, &response)
+	err = vk.RequestUnmarshal("fave.removeVideo", &response, params)
 	return
 }
 
@@ -204,7 +202,7 @@ func (vk *VK) FaveRemoveVideo(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.reorderTags
 func (vk *VK) FaveReorderTags(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.reorderTags", params, &response)
+	err = vk.RequestUnmarshal("fave.reorderTags", &response, params)
 	return
 }
 
@@ -212,7 +210,7 @@ func (vk *VK) FaveReorderTags(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.setPageTags
 func (vk *VK) FaveSetPageTags(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.setPageTags", params, &response)
+	err = vk.RequestUnmarshal("fave.setPageTags", &response, params)
 	return
 }
 
@@ -220,7 +218,7 @@ func (vk *VK) FaveSetPageTags(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.setTags
 func (vk *VK) FaveSetTags(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.setTags", params, &response)
+	err = vk.RequestUnmarshal("fave.setTags", &response, params)
 	return
 }
 
@@ -228,6 +226,6 @@ func (vk *VK) FaveSetTags(params Params) (response int, err error) {
 //
 // https://vk.com/dev/fave.trackPageInteraction
 func (vk *VK) FaveTrackPageInteraction(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("fave.trackPageInteraction", params, &response)
+	err = vk.RequestUnmarshal("fave.trackPageInteraction", &response, params)
 	return
 }

--- a/api/fave_test.go
+++ b/api/fave_test.go
@@ -137,7 +137,7 @@ func TestVK_Fave(t *testing.T) {
 
 	needUserToken(t)
 
-	fave, err := vkUser.FaveGet(api.Params{})
+	fave, err := vkUser.FaveGet(nil)
 	if !noError(t, err) {
 		log.Fatal(err)
 	}
@@ -368,7 +368,7 @@ func TestVK_FaveTag(t *testing.T) {
 	noError(t, err)
 	assert.NotEmpty(t, res)
 
-	tags, err := vkUser.FaveGetTags(api.Params{})
+	tags, err := vkUser.FaveGetTags(nil)
 	noError(t, err)
 	assert.NotEmpty(t, tags)
 
@@ -430,13 +430,13 @@ func TestVK_FaveGet(t *testing.T) {
 
 	time.Sleep(sleepTime)
 
-	res, err := vkUser.FaveGet(api.Params{})
+	res, err := vkUser.FaveGet(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res)
 
 	time.Sleep(sleepTime)
 
-	_, err = vkUser.FaveGetExtended(api.Params{})
+	_, err = vkUser.FaveGetExtended(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res)
 }
@@ -448,7 +448,7 @@ func TestVK_FaveGetPages(t *testing.T) {
 
 	time.Sleep(sleepTime)
 
-	res, err := vkUser.FaveGetPages(api.Params{})
+	res, err := vkUser.FaveGetPages(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.Count)
 
@@ -489,7 +489,7 @@ func TestVK_FaveMarkSeen(t *testing.T) {
 
 	time.Sleep(sleepTime)
 
-	res, err := vkUser.FaveMarkSeen(api.Params{})
+	res, err := vkUser.FaveMarkSeen(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res)
 }

--- a/api/friends.go
+++ b/api/friends.go
@@ -8,7 +8,7 @@ import (
 //
 // https://vk.com/dev/friends.add
 func (vk *VK) FriendsAdd(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("friends.add", params, &response)
+	err = vk.RequestUnmarshal("friends.add", &response, params)
 	return
 }
 
@@ -21,7 +21,7 @@ type FriendsAddListResponse struct {
 //
 // https://vk.com/dev/friends.addList
 func (vk *VK) FriendsAddList(params Params) (response FriendsAddListResponse, err error) {
-	err = vk.RequestUnmarshal("friends.addList", params, &response)
+	err = vk.RequestUnmarshal("friends.addList", &response, params)
 	return
 }
 
@@ -32,7 +32,7 @@ type FriendsAreFriendsResponse []object.FriendsFriendStatus
 //
 // https://vk.com/dev/friends.areFriends
 func (vk *VK) FriendsAreFriends(params Params) (response FriendsAreFriendsResponse, err error) {
-	err = vk.RequestUnmarshal("friends.areFriends", params, &response)
+	err = vk.RequestUnmarshal("friends.areFriends", &response, params)
 	return
 }
 
@@ -49,7 +49,7 @@ type FriendsDeleteResponse struct {
 //
 // https://vk.com/dev/friends.delete
 func (vk *VK) FriendsDelete(params Params) (response FriendsDeleteResponse, err error) {
-	err = vk.RequestUnmarshal("friends.delete", params, &response)
+	err = vk.RequestUnmarshal("friends.delete", &response, params)
 	return
 }
 
@@ -57,7 +57,7 @@ func (vk *VK) FriendsDelete(params Params) (response FriendsDeleteResponse, err 
 //
 // https://vk.com/dev/friends.deleteAllRequests
 func (vk *VK) FriendsDeleteAllRequests(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("friends.deleteAllRequests", params, &response)
+	err = vk.RequestUnmarshal("friends.deleteAllRequests", &response, params)
 	return
 }
 
@@ -65,7 +65,7 @@ func (vk *VK) FriendsDeleteAllRequests(params Params) (response int, err error) 
 //
 // https://vk.com/dev/friends.deleteList
 func (vk *VK) FriendsDeleteList(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("friends.deleteList", params, &response)
+	err = vk.RequestUnmarshal("friends.deleteList", &response, params)
 	return
 }
 
@@ -73,7 +73,7 @@ func (vk *VK) FriendsDeleteList(params Params) (response int, err error) {
 //
 // https://vk.com/dev/friends.edit
 func (vk *VK) FriendsEdit(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("friends.edit", params, &response)
+	err = vk.RequestUnmarshal("friends.edit", &response, params)
 	return
 }
 
@@ -81,7 +81,7 @@ func (vk *VK) FriendsEdit(params Params) (response int, err error) {
 //
 // https://vk.com/dev/friends.editList
 func (vk *VK) FriendsEditList(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("friends.editList", params, &response)
+	err = vk.RequestUnmarshal("friends.editList", &response, params)
 	return
 }
 
@@ -95,7 +95,7 @@ type FriendsGetResponse struct {
 //
 // https://vk.com/dev/friends.get
 func (vk *VK) FriendsGet(params Params) (response FriendsGetResponse, err error) {
-	err = vk.RequestUnmarshal("friends.get", params, &response)
+	err = vk.RequestUnmarshal("friends.get", &response, params)
 	return
 }
 
@@ -109,11 +109,12 @@ type FriendsGetFieldsResponse struct {
 //
 // https://vk.com/dev/friends.get
 func (vk *VK) FriendsGetFields(params Params) (response FriendsGetFieldsResponse, err error) {
+	reqParams := make(Params)
 	if v, prs := params["fields"]; v == "" || !prs {
-		params["fields"] = "id"
+		reqParams["fields"] = "id"
 	}
 
-	err = vk.RequestUnmarshal("friends.get", params, &response)
+	err = vk.RequestUnmarshal("friends.get", &response, params, reqParams)
 
 	return
 }
@@ -125,7 +126,7 @@ type FriendsGetAppUsersResponse []int
 //
 // https://vk.com/dev/friends.getAppUsers
 func (vk *VK) FriendsGetAppUsers(params Params) (response FriendsGetAppUsersResponse, err error) {
-	err = vk.RequestUnmarshal("friends.getAppUsers", params, &response)
+	err = vk.RequestUnmarshal("friends.getAppUsers", &response, params)
 	return
 }
 
@@ -137,7 +138,7 @@ type FriendsGetByPhonesResponse []object.FriendsUserXtrPhone
 //
 // https://vk.com/dev/friends.getByPhones
 func (vk *VK) FriendsGetByPhones(params Params) (response FriendsGetByPhonesResponse, err error) {
-	err = vk.RequestUnmarshal("friends.getByPhones", params, &response)
+	err = vk.RequestUnmarshal("friends.getByPhones", &response, params)
 	return
 }
 
@@ -151,7 +152,7 @@ type FriendsGetListsResponse struct {
 //
 // https://vk.com/dev/friends.getLists
 func (vk *VK) FriendsGetLists(params Params) (response FriendsGetListsResponse, err error) {
-	err = vk.RequestUnmarshal("friends.getLists", params, &response)
+	err = vk.RequestUnmarshal("friends.getLists", &response, params)
 	return
 }
 
@@ -162,7 +163,7 @@ type FriendsGetMutualResponse []int
 //
 // https://vk.com/dev/friends.getMutual
 func (vk *VK) FriendsGetMutual(params Params) (response FriendsGetMutualResponse, err error) {
-	err = vk.RequestUnmarshal("friends.getMutual", params, &response)
+	err = vk.RequestUnmarshal("friends.getMutual", &response, params)
 	return
 }
 
@@ -172,8 +173,7 @@ func (vk *VK) FriendsGetMutual(params Params) (response FriendsGetMutualResponse
 //
 // https://vk.com/dev/friends.getOnline
 func (vk *VK) FriendsGetOnline(params Params) (response []int, err error) {
-	params["online_mobile"] = false
-	err = vk.RequestUnmarshal("friends.getOnline", params, &response)
+	err = vk.RequestUnmarshal("friends.getOnline", &response, params, Params{"online_mobile": false})
 
 	return
 }
@@ -190,8 +190,7 @@ type FriendsGetOnlineOnlineMobileResponse struct {
 //
 // https://vk.com/dev/friends.getOnline
 func (vk *VK) FriendsGetOnlineOnlineMobile(params Params) (response FriendsGetOnlineOnlineMobileResponse, err error) {
-	params["online_mobile"] = true
-	err = vk.RequestUnmarshal("friends.getOnline", params, &response)
+	err = vk.RequestUnmarshal("friends.getOnline", &response, params, Params{"online_mobile": true})
 
 	return
 }
@@ -203,7 +202,7 @@ type FriendsGetRecentResponse []int
 //
 // https://vk.com/dev/friends.getRecent
 func (vk *VK) FriendsGetRecent(params Params) (response FriendsGetRecentResponse, err error) {
-	err = vk.RequestUnmarshal("friends.getRecent", params, &response)
+	err = vk.RequestUnmarshal("friends.getRecent", &response, params)
 	return
 }
 
@@ -217,9 +216,12 @@ type FriendsGetRequestsResponse struct {
 //
 // https://vk.com/dev/friends.getRequests
 func (vk *VK) FriendsGetRequests(params Params) (response FriendsGetRequestsResponse, err error) {
-	params["need_mutual"] = false
-	params["extended"] = false
-	err = vk.RequestUnmarshal("friends.getRequests", params, &response)
+	reqParams := Params{
+		"need_mutual": false,
+		"extended":    false,
+	}
+
+	err = vk.RequestUnmarshal("friends.getRequests", &response, params, reqParams)
 
 	return
 }
@@ -234,9 +236,12 @@ type FriendsGetRequestsNeedMutualResponse struct {
 //
 // https://vk.com/dev/friends.getRequests
 func (vk *VK) FriendsGetRequestsNeedMutual(params Params) (response FriendsGetRequestsNeedMutualResponse, err error) {
-	params["need_mutual"] = true
-	params["extended"] = false
-	err = vk.RequestUnmarshal("friends.getRequests", params, &response)
+	reqParams := Params{
+		"extended":    false,
+		"need_mutual": true,
+	}
+
+	err = vk.RequestUnmarshal("friends.getRequests", &response, params, reqParams)
 
 	return
 }
@@ -251,9 +256,12 @@ type FriendsGetRequestsExtendedResponse struct {
 //
 // https://vk.com/dev/friends.getRequests
 func (vk *VK) FriendsGetRequestsExtended(params Params) (response FriendsGetRequestsExtendedResponse, err error) {
-	params["need_mutual"] = false
-	params["extended"] = true
-	err = vk.RequestUnmarshal("friends.getRequests", params, &response)
+	reqParams := Params{
+		"need_mutual": false,
+		"extended":    true,
+	}
+
+	err = vk.RequestUnmarshal("friends.getRequests", &response, params, reqParams)
 
 	return
 }
@@ -268,7 +276,7 @@ type FriendsGetSuggestionsResponse struct {
 //
 // https://vk.com/dev/friends.getSuggestions
 func (vk *VK) FriendsGetSuggestions(params Params) (response FriendsGetSuggestionsResponse, err error) {
-	err = vk.RequestUnmarshal("friends.getSuggestions", params, &response)
+	err = vk.RequestUnmarshal("friends.getSuggestions", &response, params)
 	return
 }
 
@@ -282,6 +290,6 @@ type FriendsSearchResponse struct {
 //
 // https://vk.com/dev/friends.search
 func (vk *VK) FriendsSearch(params Params) (response FriendsSearchResponse, err error) {
-	err = vk.RequestUnmarshal("friends.search", params, &response)
+	err = vk.RequestUnmarshal("friends.search", &response, params)
 	return
 }

--- a/api/friends_test.go
+++ b/api/friends_test.go
@@ -44,7 +44,7 @@ func TestVK_FriendsList(t *testing.T) {
 	noError(t, err)
 	assert.NotEmpty(t, res)
 
-	lists, err := vkUser.FriendsGetLists(api.Params{})
+	lists, err := vkUser.FriendsGetLists(nil)
 	noError(t, err)
 	assert.NotEmpty(t, lists.Count)
 	assert.NotEmpty(t, lists.Items)
@@ -74,7 +74,7 @@ func TestVK_FriendsDeleteAllRequests(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.FriendsDeleteAllRequests(api.Params{})
+	res, err := vkUser.FriendsDeleteAllRequests(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res)
 }
@@ -86,7 +86,7 @@ func TestVK_FriendsEdit(t *testing.T) {
 	// NOTE: https://vk.com/bug191897
 	needUserToken(t)
 
-	_, _ = vkUser.FriendsEdit(api.Params{})
+	_, _ = vkUser.FriendsEdit(nil)
 }
 
 func TestVK_FriendsGet(t *testing.T) {
@@ -115,7 +115,7 @@ func TestVK_FriendsGetAppUsers(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.FriendsGetAppUsers(api.Params{})
+	_, err := vkUser.FriendsGetAppUsers(nil)
 	noError(t, err)
 }
 
@@ -148,10 +148,10 @@ func TestVK_FriendsGetOnline(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.FriendsGetOnline(api.Params{})
+	_, err := vkUser.FriendsGetOnline(nil)
 	noError(t, err)
 
-	_, err = vkUser.FriendsGetOnlineOnlineMobile(api.Params{})
+	_, err = vkUser.FriendsGetOnlineOnlineMobile(nil)
 	noError(t, err)
 }
 
@@ -160,7 +160,7 @@ func TestVK_FriendsGetRecent(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.FriendsGetRecent(api.Params{})
+	_, err := vkUser.FriendsGetRecent(nil)
 	noError(t, err)
 }
 
@@ -196,7 +196,7 @@ func TestVK_FriendsGetSuggestions(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.FriendsGetSuggestions(api.Params{})
+	res, err := vkUser.FriendsGetSuggestions(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.Count)
 	assert.NotEmpty(t, res.Items)

--- a/api/gifts.go
+++ b/api/gifts.go
@@ -12,7 +12,7 @@ type GiftsGetResponse struct {
 //
 // https://vk.com/dev/gifts.get
 func (vk *VK) GiftsGet(params Params) (response GiftsGetResponse, err error) {
-	err = vk.RequestUnmarshal("gifts.get", params, &response)
+	err = vk.RequestUnmarshal("gifts.get", &response, params)
 	return
 }
 
@@ -27,6 +27,6 @@ type GiftsGetCatalogResponse []struct {
 //
 // https://vk.com/dev/gifts.get
 func (vk *VK) GiftsGetCatalog(params Params) (response GiftsGetCatalogResponse, err error) {
-	err = vk.RequestUnmarshal("gifts.getCatalog", params, &response)
+	err = vk.RequestUnmarshal("gifts.getCatalog", &response, params)
 	return
 }

--- a/api/gifts_test.go
+++ b/api/gifts_test.go
@@ -45,7 +45,7 @@ func TestVK_GiftsGetCatalog(t *testing.T) {
 	needUserToken(t)
 
 	// NOTE: Access denied: method allowed only for official app
-	_, err := vkUser.GiftsGetCatalog(api.Params{})
+	_, err := vkUser.GiftsGetCatalog(nil)
 	if e, ok := err.(*api.Error); ok && e.Code == api.ErrAccess {
 		t.Errorf("VK.GiftsGetCatalog() err = %v", err)
 	}

--- a/api/groups.go
+++ b/api/groups.go
@@ -11,7 +11,7 @@ type GroupsAddAddressResponse object.GroupsAddress
 //
 // https://vk.com/dev/groups.addAddress
 func (vk *VK) GroupsAddAddress(params Params) (response GroupsAddAddressResponse, err error) {
-	err = vk.RequestUnmarshal("groups.addAddress", params, &response)
+	err = vk.RequestUnmarshal("groups.addAddress", &response, params)
 	return
 }
 
@@ -24,7 +24,7 @@ type GroupsAddCallbackServerResponse struct {
 //
 // https://vk.com/dev/groups.addCallbackServer
 func (vk *VK) GroupsAddCallbackServer(params Params) (response GroupsAddCallbackServerResponse, err error) {
-	err = vk.RequestUnmarshal("groups.addCallbackServer", params, &response)
+	err = vk.RequestUnmarshal("groups.addCallbackServer", &response, params)
 	return
 }
 
@@ -35,7 +35,7 @@ type GroupsAddLinkResponse object.GroupsGroupLink
 //
 // https://vk.com/dev/groups.addLink
 func (vk *VK) GroupsAddLink(params Params) (response GroupsAddLinkResponse, err error) {
-	err = vk.RequestUnmarshal("groups.addLink", params, &response)
+	err = vk.RequestUnmarshal("groups.addLink", &response, params)
 	return
 }
 
@@ -43,7 +43,7 @@ func (vk *VK) GroupsAddLink(params Params) (response GroupsAddLinkResponse, err 
 //
 // https://vk.com/dev/groups.approveRequest
 func (vk *VK) GroupsApproveRequest(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.approveRequest", params, &response)
+	err = vk.RequestUnmarshal("groups.approveRequest", &response, params)
 	return
 }
 
@@ -51,7 +51,7 @@ func (vk *VK) GroupsApproveRequest(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.ban
 func (vk *VK) GroupsBan(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.ban", params, &response)
+	err = vk.RequestUnmarshal("groups.ban", &response, params)
 	return
 }
 
@@ -62,7 +62,7 @@ type GroupsCreateResponse object.GroupsGroup
 //
 // https://vk.com/dev/groups.create
 func (vk *VK) GroupsCreate(params Params) (response GroupsCreateResponse, err error) {
-	err = vk.RequestUnmarshal("groups.create", params, &response)
+	err = vk.RequestUnmarshal("groups.create", &response, params)
 	return
 }
 
@@ -70,7 +70,7 @@ func (vk *VK) GroupsCreate(params Params) (response GroupsCreateResponse, err er
 //
 // https://vk.com/dev/groups.deleteAddress
 func (vk *VK) GroupsDeleteAddress(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.deleteAddress", params, &response)
+	err = vk.RequestUnmarshal("groups.deleteAddress", &response, params)
 	return
 }
 
@@ -78,7 +78,7 @@ func (vk *VK) GroupsDeleteAddress(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.deleteCallbackServer
 func (vk *VK) GroupsDeleteCallbackServer(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.deleteCallbackServer", params, &response)
+	err = vk.RequestUnmarshal("groups.deleteCallbackServer", &response, params)
 	return
 }
 
@@ -86,7 +86,7 @@ func (vk *VK) GroupsDeleteCallbackServer(params Params) (response int, err error
 //
 // https://vk.com/dev/groups.deleteLink
 func (vk *VK) GroupsDeleteLink(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.deleteLink", params, &response)
+	err = vk.RequestUnmarshal("groups.deleteLink", &response, params)
 	return
 }
 
@@ -94,7 +94,7 @@ func (vk *VK) GroupsDeleteLink(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.disableOnline
 func (vk *VK) GroupsDisableOnline(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.disableOnline", params, &response)
+	err = vk.RequestUnmarshal("groups.disableOnline", &response, params)
 	return
 }
 
@@ -102,7 +102,7 @@ func (vk *VK) GroupsDisableOnline(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.edit
 func (vk *VK) GroupsEdit(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.edit", params, &response)
+	err = vk.RequestUnmarshal("groups.edit", &response, params)
 	return
 }
 
@@ -113,7 +113,7 @@ type GroupsEditAddressResponse object.GroupsAddress
 //
 // https://vk.com/dev/groups.editAddress
 func (vk *VK) GroupsEditAddress(params Params) (response GroupsEditAddressResponse, err error) {
-	err = vk.RequestUnmarshal("groups.editAddress", params, &response)
+	err = vk.RequestUnmarshal("groups.editAddress", &response, params)
 	return
 }
 
@@ -121,7 +121,7 @@ func (vk *VK) GroupsEditAddress(params Params) (response GroupsEditAddressRespon
 //
 // https://vk.com/dev/groups.editCallbackServer
 func (vk *VK) GroupsEditCallbackServer(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.editCallbackServer", params, &response)
+	err = vk.RequestUnmarshal("groups.editCallbackServer", &response, params)
 	return
 }
 
@@ -129,7 +129,7 @@ func (vk *VK) GroupsEditCallbackServer(params Params) (response int, err error) 
 //
 // https://vk.com/dev/groups.editLink
 func (vk *VK) GroupsEditLink(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.editLink", params, &response)
+	err = vk.RequestUnmarshal("groups.editLink", &response, params)
 	return
 }
 
@@ -137,7 +137,7 @@ func (vk *VK) GroupsEditLink(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.editManager
 func (vk *VK) GroupsEditManager(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.editManager", params, &response)
+	err = vk.RequestUnmarshal("groups.editManager", &response, params)
 	return
 }
 
@@ -145,7 +145,7 @@ func (vk *VK) GroupsEditManager(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.enableOnline
 func (vk *VK) GroupsEnableOnline(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.enableOnline", params, &response)
+	err = vk.RequestUnmarshal("groups.enableOnline", &response, params)
 	return
 }
 
@@ -161,8 +161,7 @@ type GroupsGetResponse struct {
 //
 // https://vk.com/dev/groups.get
 func (vk *VK) GroupsGet(params Params) (response GroupsGetResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("groups.get", params, &response)
+	err = vk.RequestUnmarshal("groups.get", &response, params, Params{"extended": false})
 
 	return
 }
@@ -179,8 +178,7 @@ type GroupsGetExtendedResponse struct {
 //
 // https://vk.com/dev/groups.get
 func (vk *VK) GroupsGetExtended(params Params) (response GroupsGetExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("groups.get", params, &response)
+	err = vk.RequestUnmarshal("groups.get", &response, params, Params{"extended": true})
 
 	return
 }
@@ -195,7 +193,7 @@ type GroupsGetAddressesResponse struct {
 //
 // https://vk.com/dev/groups.getAddresses
 func (vk *VK) GroupsGetAddresses(params Params) (response GroupsGetAddressesResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getAddresses", params, &response)
+	err = vk.RequestUnmarshal("groups.getAddresses", &response, params)
 	return
 }
 
@@ -209,7 +207,7 @@ type GroupsGetBannedResponse struct {
 //
 // https://vk.com/dev/groups.getBanned
 func (vk *VK) GroupsGetBanned(params Params) (response GroupsGetBannedResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getBanned", params, &response)
+	err = vk.RequestUnmarshal("groups.getBanned", &response, params)
 	return
 }
 
@@ -220,7 +218,7 @@ type GroupsGetByIDResponse []object.GroupsGroup
 //
 // https://vk.com/dev/groups.getById
 func (vk *VK) GroupsGetByID(params Params) (response GroupsGetByIDResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getById", params, &response)
+	err = vk.RequestUnmarshal("groups.getById", &response, params)
 	return
 }
 
@@ -236,7 +234,7 @@ func (vk *VK) GroupsGetCallbackConfirmationCode(params Params) (
 	response GroupsGetCallbackConfirmationCodeResponse,
 	err error,
 ) {
-	err = vk.RequestUnmarshal("groups.getCallbackConfirmationCode", params, &response)
+	err = vk.RequestUnmarshal("groups.getCallbackConfirmationCode", &response, params)
 	return
 }
 
@@ -250,7 +248,7 @@ type GroupsGetCallbackServersResponse struct {
 //
 // https://vk.com/dev/groups.getCallbackServers
 func (vk *VK) GroupsGetCallbackServers(params Params) (response GroupsGetCallbackServersResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getCallbackServers", params, &response)
+	err = vk.RequestUnmarshal("groups.getCallbackServers", &response, params)
 	return
 }
 
@@ -263,7 +261,7 @@ type GroupsGetCallbackSettingsResponse object.GroupsCallbackSettings
 //
 // https://vk.com/dev/groups.getCallbackSettings
 func (vk *VK) GroupsGetCallbackSettings(params Params) (response GroupsGetCallbackSettingsResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getCallbackSettings", params, &response)
+	err = vk.RequestUnmarshal("groups.getCallbackSettings", &response, params)
 	return
 }
 
@@ -277,7 +275,7 @@ type GroupsGetCatalogResponse struct {
 //
 // https://vk.com/dev/groups.getCatalog
 func (vk *VK) GroupsGetCatalog(params Params) (response GroupsGetCatalogResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getCatalog", params, &response)
+	err = vk.RequestUnmarshal("groups.getCatalog", &response, params)
 	return
 }
 
@@ -293,8 +291,7 @@ type GroupsGetCatalogInfoResponse struct {
 //
 // https://vk.com/dev/groups.getCatalogInfo
 func (vk *VK) GroupsGetCatalogInfo(params Params) (response GroupsGetCatalogInfoResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("groups.getCatalogInfo", params, &response)
+	err = vk.RequestUnmarshal("groups.getCatalogInfo", &response, params, Params{"extended": false})
 
 	return
 }
@@ -311,8 +308,7 @@ type GroupsGetCatalogInfoExtendedResponse struct {
 //
 // https://vk.com/dev/groups.getCatalogInfo
 func (vk *VK) GroupsGetCatalogInfoExtended(params Params) (response GroupsGetCatalogInfoExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("groups.getCatalogInfo", params, &response)
+	err = vk.RequestUnmarshal("groups.getCatalogInfo", &response, params, Params{"extended": true})
 
 	return
 }
@@ -327,7 +323,7 @@ type GroupsGetInvitedUsersResponse struct {
 //
 // https://vk.com/dev/groups.getInvitedUsers
 func (vk *VK) GroupsGetInvitedUsers(params Params) (response GroupsGetInvitedUsersResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getInvitedUsers", params, &response)
+	err = vk.RequestUnmarshal("groups.getInvitedUsers", &response, params)
 	return
 }
 
@@ -341,7 +337,7 @@ type GroupsGetInvitesResponse struct {
 //
 // https://vk.com/dev/groups.getInvites
 func (vk *VK) GroupsGetInvites(params Params) (response GroupsGetInvitesResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getInvites", params, &response)
+	err = vk.RequestUnmarshal("groups.getInvites", &response, params)
 	return
 }
 
@@ -356,7 +352,7 @@ type GroupsGetInvitesExtendedResponse struct {
 //
 // https://vk.com/dev/groups.getInvites
 func (vk *VK) GroupsGetInvitesExtended(params Params) (response GroupsGetInvitesExtendedResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getInvites", params, &response)
+	err = vk.RequestUnmarshal("groups.getInvites", &response, params)
 	return
 }
 
@@ -367,7 +363,7 @@ type GroupsGetLongPollServerResponse object.GroupsLongPollServer
 //
 // https://vk.com/dev/groups.getLongPollServer
 func (vk *VK) GroupsGetLongPollServer(params Params) (response GroupsGetLongPollServerResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getLongPollServer", params, &response)
+	err = vk.RequestUnmarshal("groups.getLongPollServer", &response, params)
 	return
 }
 
@@ -378,7 +374,7 @@ type GroupsGetLongPollSettingsResponse object.GroupsLongPollSettings
 //
 // https://vk.com/dev/groups.getLongPollSettings
 func (vk *VK) GroupsGetLongPollSettings(params Params) (response GroupsGetLongPollSettingsResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getLongPollSettings", params, &response)
+	err = vk.RequestUnmarshal("groups.getLongPollSettings", &response, params)
 	return
 }
 
@@ -392,9 +388,7 @@ type GroupsGetMembersResponse struct {
 //
 // https://vk.com/dev/groups.getMembers
 func (vk *VK) GroupsGetMembers(params Params) (response GroupsGetMembersResponse, err error) {
-	params["fields"] = ""
-	params["filter"] = ""
-	err = vk.RequestUnmarshal("groups.getMembers", params, &response)
+	err = vk.RequestUnmarshal("groups.getMembers", &response, params, Params{"filter": ""})
 
 	return
 }
@@ -409,11 +403,12 @@ type GroupsGetMembersFieldsResponse struct {
 //
 // https://vk.com/dev/groups.getMembers
 func (vk *VK) GroupsGetMembersFields(params Params) (response GroupsGetMembersFieldsResponse, err error) {
+	reqParams := make(Params)
 	if v, prs := params["fields"]; v == "" || !prs {
-		params["fields"] = "id"
+		reqParams["fields"] = "id"
 	}
 
-	err = vk.RequestUnmarshal("groups.getMembers", params, &response)
+	err = vk.RequestUnmarshal("groups.getMembers", &response, params, reqParams)
 
 	return
 }
@@ -432,8 +427,7 @@ func (vk *VK) GroupsGetMembersFilterManagers(params Params) (
 	response GroupsGetMembersFilterManagersResponse,
 	err error,
 ) {
-	params["filter"] = "managers"
-	err = vk.RequestUnmarshal("groups.getMembers", params, &response)
+	err = vk.RequestUnmarshal("groups.getMembers", &response, params, Params{"filter": "managers"})
 
 	return
 }
@@ -445,7 +439,7 @@ type GroupsGetOnlineStatusResponse object.GroupsOnlineStatus
 //
 // https://vk.com/dev/groups.getOnlineStatus
 func (vk *VK) GroupsGetOnlineStatus(params Params) (response GroupsGetOnlineStatusResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getOnlineStatus", params, &response)
+	err = vk.RequestUnmarshal("groups.getOnlineStatus", &response, params)
 	return
 }
 
@@ -459,8 +453,7 @@ type GroupsGetRequestsResponse struct {
 //
 // https://vk.com/dev/groups.getRequests
 func (vk *VK) GroupsGetRequests(params Params) (response GroupsGetRequestsResponse, err error) {
-	params["fields"] = ""
-	err = vk.RequestUnmarshal("groups.getRequests", params, &response)
+	err = vk.RequestUnmarshal("groups.getRequests", &response, params, Params{"fields": ""})
 
 	return
 }
@@ -475,11 +468,12 @@ type GroupsGetRequestsFieldsResponse struct {
 //
 // https://vk.com/dev/groups.getRequests
 func (vk *VK) GroupsGetRequestsFields(params Params) (response GroupsGetRequestsFieldsResponse, err error) {
+	reqParams := make(Params)
 	if v, prs := params["fields"]; v == "" || !prs {
-		params["fields"] = "id"
+		reqParams["fields"] = "id"
 	}
 
-	err = vk.RequestUnmarshal("groups.getRequests", params, &response)
+	err = vk.RequestUnmarshal("groups.getRequests", &response, params, reqParams)
 
 	return
 }
@@ -491,7 +485,7 @@ type GroupsGetSettingsResponse object.GroupsGroupSettings
 //
 // https://vk.com/dev/groups.getSettings
 func (vk *VK) GroupsGetSettings(params Params) (response GroupsGetSettingsResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getSettings", params, &response)
+	err = vk.RequestUnmarshal("groups.getSettings", &response, params)
 	return
 }
 
@@ -502,7 +496,7 @@ type GroupsGetTagListResponse []object.GroupsTag
 //
 // https://vk.com/dev/groups.getTagList
 func (vk *VK) GroupsGetTagList(params Params) (response GroupsGetTagListResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getTagList", params, &response)
+	err = vk.RequestUnmarshal("groups.getTagList", &response, params)
 	return
 }
 
@@ -513,7 +507,7 @@ type GroupsGetTokenPermissionsResponse object.GroupsTokenPermissions
 //
 // https://vk.com/dev/groups.getTokenPermissions
 func (vk *VK) GroupsGetTokenPermissions(params Params) (response GroupsGetTokenPermissionsResponse, err error) {
-	err = vk.RequestUnmarshal("groups.getTokenPermissions", params, &response)
+	err = vk.RequestUnmarshal("groups.getTokenPermissions", &response, params)
 	return
 }
 
@@ -521,7 +515,7 @@ func (vk *VK) GroupsGetTokenPermissions(params Params) (response GroupsGetTokenP
 //
 // https://vk.com/dev/groups.invite
 func (vk *VK) GroupsInvite(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.invite", params, &response)
+	err = vk.RequestUnmarshal("groups.invite", &response, params)
 	return
 }
 
@@ -531,8 +525,7 @@ func (vk *VK) GroupsInvite(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.isMember
 func (vk *VK) GroupsIsMember(params Params) (response int, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("groups.isMember", params, &response)
+	err = vk.RequestUnmarshal("groups.isMember", &response, params, Params{"extended": false})
 
 	return
 }
@@ -552,8 +545,7 @@ type GroupsIsMemberExtendedResponse struct {
 //
 // https://vk.com/dev/groups.isMember
 func (vk *VK) GroupsIsMemberExtended(params Params) (response GroupsIsMemberExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("groups.isMember", params, &response)
+	err = vk.RequestUnmarshal("groups.isMember", &response, params, Params{"extended": true})
 
 	return
 }
@@ -568,8 +560,7 @@ type GroupsIsMemberUserIDsExtendedResponse []object.GroupsMemberStatusFull
 //
 // https://vk.com/dev/groups.isMember
 func (vk *VK) GroupsIsMemberUserIDsExtended(params Params) (response GroupsIsMemberUserIDsExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("groups.isMember", params, &response)
+	err = vk.RequestUnmarshal("groups.isMember", &response, params, Params{"extended": true})
 
 	return
 }
@@ -584,8 +575,7 @@ type GroupsIsMemberUserIDsResponse []object.GroupsMemberStatus
 //
 // https://vk.com/dev/groups.isMember
 func (vk *VK) GroupsIsMemberUserIDs(params Params) (response GroupsIsMemberUserIDsResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("groups.isMember", params, &response)
+	err = vk.RequestUnmarshal("groups.isMember", &response, params, Params{"extended": false})
 
 	return
 }
@@ -594,7 +584,7 @@ func (vk *VK) GroupsIsMemberUserIDs(params Params) (response GroupsIsMemberUserI
 //
 // https://vk.com/dev/groups.join
 func (vk *VK) GroupsJoin(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.join", params, &response)
+	err = vk.RequestUnmarshal("groups.join", &response, params)
 	return
 }
 
@@ -602,7 +592,7 @@ func (vk *VK) GroupsJoin(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.leave
 func (vk *VK) GroupsLeave(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.leave", params, &response)
+	err = vk.RequestUnmarshal("groups.leave", &response, params)
 	return
 }
 
@@ -610,7 +600,7 @@ func (vk *VK) GroupsLeave(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.removeUser
 func (vk *VK) GroupsRemoveUser(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.removeUser", params, &response)
+	err = vk.RequestUnmarshal("groups.removeUser", &response, params)
 	return
 }
 
@@ -618,7 +608,7 @@ func (vk *VK) GroupsRemoveUser(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.reorderLink
 func (vk *VK) GroupsReorderLink(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.reorderLink", params, &response)
+	err = vk.RequestUnmarshal("groups.reorderLink", &response, params)
 	return
 }
 
@@ -632,7 +622,7 @@ type GroupsSearchResponse struct {
 //
 // https://vk.com/dev/groups.search
 func (vk *VK) GroupsSearch(params Params) (response GroupsSearchResponse, err error) {
-	err = vk.RequestUnmarshal("groups.search", params, &response)
+	err = vk.RequestUnmarshal("groups.search", &response, params)
 	return
 }
 
@@ -640,7 +630,7 @@ func (vk *VK) GroupsSearch(params Params) (response GroupsSearchResponse, err er
 //
 // https://vk.com/dev/groups.setCallbackSettings
 func (vk *VK) GroupsSetCallbackSettings(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.setCallbackSettings", params, &response)
+	err = vk.RequestUnmarshal("groups.setCallbackSettings", &response, params)
 	return
 }
 
@@ -648,7 +638,7 @@ func (vk *VK) GroupsSetCallbackSettings(params Params) (response int, err error)
 //
 // https://vk.com/dev/groups.setLongPollSettings
 func (vk *VK) GroupsSetLongPollSettings(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.setLongPollSettings", params, &response)
+	err = vk.RequestUnmarshal("groups.setLongPollSettings", &response, params)
 	return
 }
 
@@ -656,7 +646,7 @@ func (vk *VK) GroupsSetLongPollSettings(params Params) (response int, err error)
 //
 // https://vk.com/dev/groups.setSettings
 func (vk *VK) GroupsSetSettings(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.setSettings", params, &response)
+	err = vk.RequestUnmarshal("groups.setSettings", &response, params)
 	return
 }
 
@@ -665,7 +655,7 @@ func (vk *VK) GroupsSetSettings(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.setUserNote
 func (vk *VK) GroupsSetUserNote(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.setUserNote", params, &response)
+	err = vk.RequestUnmarshal("groups.setUserNote", &response, params)
 	return
 }
 
@@ -673,7 +663,7 @@ func (vk *VK) GroupsSetUserNote(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.tagAdd
 func (vk *VK) GroupsTagAdd(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.tagAdd", params, &response)
+	err = vk.RequestUnmarshal("groups.tagAdd", &response, params)
 	return
 }
 
@@ -681,7 +671,7 @@ func (vk *VK) GroupsTagAdd(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.tagBind
 func (vk *VK) GroupsTagBind(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.tagBind", params, &response)
+	err = vk.RequestUnmarshal("groups.tagBind", &response, params)
 	return
 }
 
@@ -692,7 +682,7 @@ func (vk *VK) GroupsTagBind(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.tagDelete
 func (vk *VK) GroupsTagDelete(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.tagDelete", params, &response)
+	err = vk.RequestUnmarshal("groups.tagDelete", &response, params)
 	return
 }
 
@@ -700,7 +690,7 @@ func (vk *VK) GroupsTagDelete(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.tagUpdate
 func (vk *VK) GroupsTagUpdate(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.tagUpdate", params, &response)
+	err = vk.RequestUnmarshal("groups.tagUpdate", &response, params)
 	return
 }
 
@@ -708,7 +698,7 @@ func (vk *VK) GroupsTagUpdate(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.toggleMarket
 func (vk *VK) GroupsToggleMarket(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.toggleMarket", params, &response)
+	err = vk.RequestUnmarshal("groups.toggleMarket", &response, params)
 	return
 }
 
@@ -716,6 +706,6 @@ func (vk *VK) GroupsToggleMarket(params Params) (response int, err error) {
 //
 // https://vk.com/dev/groups.unban
 func (vk *VK) GroupsUnban(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("groups.unban", params, &response)
+	err = vk.RequestUnmarshal("groups.unban", &response, params)
 	return
 }

--- a/api/groups_test.go
+++ b/api/groups_test.go
@@ -694,7 +694,7 @@ func TestVK_GroupsGetCatalogInfo(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.GroupsGetCatalogInfo(api.Params{})
+	res, err := vkUser.GroupsGetCatalogInfo(nil)
 	noError(t, err)
 	// assert.NotEmpty(t, res.Categories[0].ID)
 	assert.NotEmpty(t, res.Enabled)
@@ -705,7 +705,7 @@ func TestVK_GroupsGetCatalogInfoExtended(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.GroupsGetCatalogInfoExtended(api.Params{})
+	res, err := vkUser.GroupsGetCatalogInfoExtended(nil)
 	noError(t, err)
 	// if assert.NotEmpty(t, res.Categories) {
 	// 	assert.NotEmpty(t, res.Categories[0].Name)
@@ -732,7 +732,7 @@ func TestVK_GroupsGetInvites(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.GroupsGetInvites(api.Params{})
+	_, err := vkUser.GroupsGetInvites(nil)
 	noError(t, err)
 }
 
@@ -741,7 +741,7 @@ func TestVK_GroupsGetInvitesExtended(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.GroupsGetInvitesExtended(api.Params{})
+	_, err := vkUser.GroupsGetInvitesExtended(nil)
 	noError(t, err)
 }
 
@@ -869,7 +869,7 @@ func TestVK_GroupsGetTokenPermissions(t *testing.T) {
 
 	needGroupToken(t)
 
-	res, err := vkGroup.GroupsGetTokenPermissions(api.Params{})
+	res, err := vkGroup.GroupsGetTokenPermissions(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.Mask)
 	assert.NotEmpty(t, res.Permissions[0].Name)

--- a/api/leadforms.go
+++ b/api/leadforms.go
@@ -14,7 +14,7 @@ type LeadFormsCreateResponse struct {
 //
 // https://vk.com/dev/leadForms.create
 func (vk *VK) LeadFormsCreate(params Params) (response LeadFormsCreateResponse, err error) {
-	err = vk.RequestUnmarshal("leadForms.create", params, &response)
+	err = vk.RequestUnmarshal("leadForms.create", &response, params)
 	return
 }
 
@@ -27,7 +27,7 @@ type LeadFormsDeleteResponse struct {
 //
 // https://vk.com/dev/leadForms.delete
 func (vk *VK) LeadFormsDelete(params Params) (response LeadFormsDeleteResponse, err error) {
-	err = vk.RequestUnmarshal("leadForms.delete", params, &response)
+	err = vk.RequestUnmarshal("leadForms.delete", &response, params)
 	return
 }
 
@@ -38,7 +38,7 @@ type LeadFormsGetResponse object.LeadFormsForm
 //
 // https://vk.com/dev/leadForms.get
 func (vk *VK) LeadFormsGet(params Params) (response LeadFormsGetResponse, err error) {
-	err = vk.RequestUnmarshal("leadForms.get", params, &response)
+	err = vk.RequestUnmarshal("leadForms.get", &response, params)
 	return
 }
 
@@ -51,7 +51,7 @@ type LeadFormsGetLeadsResponse struct {
 //
 // https://vk.com/dev/leadForms.getLeads
 func (vk *VK) LeadFormsGetLeads(params Params) (response LeadFormsGetLeadsResponse, err error) {
-	err = vk.RequestUnmarshal("leadForms.getLeads", params, &response)
+	err = vk.RequestUnmarshal("leadForms.getLeads", &response, params)
 	return
 }
 
@@ -59,7 +59,7 @@ func (vk *VK) LeadFormsGetLeads(params Params) (response LeadFormsGetLeadsRespon
 //
 // https://vk.com/dev/leadForms.getUploadURL
 func (vk *VK) LeadFormsGetUploadURL(params Params) (response string, err error) {
-	err = vk.RequestUnmarshal("leadForms.getUploadURL", params, &response)
+	err = vk.RequestUnmarshal("leadForms.getUploadURL", &response, params)
 	return
 }
 
@@ -70,7 +70,7 @@ type LeadFormsListResponse []object.LeadFormsForm
 //
 // https://vk.com/dev/leadForms.list
 func (vk *VK) LeadFormsList(params Params) (response LeadFormsListResponse, err error) {
-	err = vk.RequestUnmarshal("leadForms.list", params, &response)
+	err = vk.RequestUnmarshal("leadForms.list", &response, params)
 	return
 }
 
@@ -84,6 +84,6 @@ type LeadFormsUpdateResponse struct {
 //
 // https://vk.com/dev/leadForms.update
 func (vk *VK) LeadFormsUpdate(params Params) (response LeadFormsUpdateResponse, err error) {
-	err = vk.RequestUnmarshal("leadForms.update", params, &response)
+	err = vk.RequestUnmarshal("leadForms.update", &response, params)
 	return
 }

--- a/api/leads.go
+++ b/api/leads.go
@@ -11,7 +11,7 @@ type LeadsCheckUserResponse object.LeadsChecked
 //
 // https://vk.com/dev/leads.checkUser
 func (vk *VK) LeadsCheckUser(params Params) (response LeadsCheckUserResponse, err error) {
-	err = vk.RequestUnmarshal("leads.checkUser", params, &response)
+	err = vk.RequestUnmarshal("leads.checkUser", &response, params)
 	return
 }
 
@@ -22,7 +22,7 @@ type LeadsCompleteResponse object.LeadsComplete
 //
 // https://vk.com/dev/leads.complete
 func (vk *VK) LeadsComplete(params Params) (response LeadsCompleteResponse, err error) {
-	err = vk.RequestUnmarshal("leads.complete", params, &response)
+	err = vk.RequestUnmarshal("leads.complete", &response, params)
 	return
 }
 
@@ -33,7 +33,7 @@ type LeadsGetStatsResponse object.LeadsLead
 //
 // https://vk.com/dev/leads.getStats
 func (vk *VK) LeadsGetStats(params Params) (response LeadsGetStatsResponse, err error) {
-	err = vk.RequestUnmarshal("leads.getStats", params, &response)
+	err = vk.RequestUnmarshal("leads.getStats", &response, params)
 	return
 }
 
@@ -44,7 +44,7 @@ type LeadsGetUsersResponse object.LeadsEntry
 //
 // https://vk.com/dev/leads.getUsers
 func (vk *VK) LeadsGetUsers(params Params) (response LeadsGetUsersResponse, err error) {
-	err = vk.RequestUnmarshal("leads.getUsers", params, &response)
+	err = vk.RequestUnmarshal("leads.getUsers", &response, params)
 	return
 }
 
@@ -58,7 +58,7 @@ type LeadsMetricHitResponse struct {
 //
 // https://vk.com/dev/leads.metricHit
 func (vk *VK) LeadsMetricHit(params Params) (response LeadsMetricHitResponse, err error) {
-	err = vk.RequestUnmarshal("leads.metricHit", params, &response)
+	err = vk.RequestUnmarshal("leads.metricHit", &response, params)
 	return
 }
 
@@ -69,6 +69,6 @@ type LeadsStartResponse object.LeadsStart
 //
 // https://vk.com/dev/leads.start
 func (vk *VK) LeadsStart(params Params) (response LeadsStartResponse, err error) {
-	err = vk.RequestUnmarshal("leads.start", params, &response)
+	err = vk.RequestUnmarshal("leads.start", &response, params)
 	return
 }

--- a/api/likes.go
+++ b/api/likes.go
@@ -13,7 +13,7 @@ type LikesAddResponse struct {
 //
 // https://vk.com/dev/likes.add
 func (vk *VK) LikesAdd(params Params) (response LikesAddResponse, err error) {
-	err = vk.RequestUnmarshal("likes.add", params, &response)
+	err = vk.RequestUnmarshal("likes.add", &response, params)
 	return
 }
 
@@ -26,7 +26,7 @@ type LikesDeleteResponse struct {
 //
 // https://vk.com/dev/likes.delete
 func (vk *VK) LikesDelete(params Params) (response LikesDeleteResponse, err error) {
-	err = vk.RequestUnmarshal("likes.delete", params, &response)
+	err = vk.RequestUnmarshal("likes.delete", &response, params)
 	return
 }
 
@@ -42,8 +42,7 @@ type LikesGetListResponse struct {
 //
 // https://vk.com/dev/likes.getList
 func (vk *VK) LikesGetList(params Params) (response LikesGetListResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("likes.getList", params, &response)
+	err = vk.RequestUnmarshal("likes.getList", &response, params, Params{"extended": false})
 
 	return
 }
@@ -60,8 +59,7 @@ type LikesGetListExtendedResponse struct {
 //
 // https://vk.com/dev/likes.getList
 func (vk *VK) LikesGetListExtended(params Params) (response LikesGetListExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("likes.getList", params, &response)
+	err = vk.RequestUnmarshal("likes.getList", &response, params, Params{"extended": true})
 
 	return
 }
@@ -76,6 +74,6 @@ type LikesIsLikedResponse struct {
 //
 // https://vk.com/dev/likes.isLiked
 func (vk *VK) LikesIsLiked(params Params) (response LikesIsLikedResponse, err error) {
-	err = vk.RequestUnmarshal("likes.isLiked", params, &response)
+	err = vk.RequestUnmarshal("likes.isLiked", &response, params)
 	return
 }

--- a/api/market.go
+++ b/api/market.go
@@ -13,7 +13,7 @@ type MarketAddResponse struct {
 //
 // https://vk.com/dev/market.add
 func (vk *VK) MarketAdd(params Params) (response MarketAddResponse, err error) {
-	err = vk.RequestUnmarshal("market.add", params, &response)
+	err = vk.RequestUnmarshal("market.add", &response, params)
 	return
 }
 
@@ -26,7 +26,7 @@ type MarketAddAlbumResponse struct {
 //
 // https://vk.com/dev/market.addAlbum
 func (vk *VK) MarketAddAlbum(params Params) (response MarketAddAlbumResponse, err error) {
-	err = vk.RequestUnmarshal("market.addAlbum", params, &response)
+	err = vk.RequestUnmarshal("market.addAlbum", &response, params)
 	return
 }
 
@@ -34,7 +34,7 @@ func (vk *VK) MarketAddAlbum(params Params) (response MarketAddAlbumResponse, er
 //
 // https://vk.com/dev/market.addToAlbum
 func (vk *VK) MarketAddToAlbum(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.addToAlbum", params, &response)
+	err = vk.RequestUnmarshal("market.addToAlbum", &response, params)
 	return
 }
 
@@ -42,7 +42,7 @@ func (vk *VK) MarketAddToAlbum(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.createComment
 func (vk *VK) MarketCreateComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.createComment", params, &response)
+	err = vk.RequestUnmarshal("market.createComment", &response, params)
 	return
 }
 
@@ -50,7 +50,7 @@ func (vk *VK) MarketCreateComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.delete
 func (vk *VK) MarketDelete(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.delete", params, &response)
+	err = vk.RequestUnmarshal("market.delete", &response, params)
 	return
 }
 
@@ -58,7 +58,7 @@ func (vk *VK) MarketDelete(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.deleteAlbum
 func (vk *VK) MarketDeleteAlbum(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.deleteAlbum", params, &response)
+	err = vk.RequestUnmarshal("market.deleteAlbum", &response, params)
 	return
 }
 
@@ -66,7 +66,7 @@ func (vk *VK) MarketDeleteAlbum(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.deleteComment
 func (vk *VK) MarketDeleteComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.deleteComment", params, &response)
+	err = vk.RequestUnmarshal("market.deleteComment", &response, params)
 	return
 }
 
@@ -74,7 +74,7 @@ func (vk *VK) MarketDeleteComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.edit
 func (vk *VK) MarketEdit(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.edit", params, &response)
+	err = vk.RequestUnmarshal("market.edit", &response, params)
 	return
 }
 
@@ -82,7 +82,7 @@ func (vk *VK) MarketEdit(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.editAlbum
 func (vk *VK) MarketEditAlbum(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.editAlbum", params, &response)
+	err = vk.RequestUnmarshal("market.editAlbum", &response, params)
 	return
 }
 
@@ -90,7 +90,7 @@ func (vk *VK) MarketEditAlbum(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.editComment
 func (vk *VK) MarketEditComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.editComment", params, &response)
+	err = vk.RequestUnmarshal("market.editComment", &response, params)
 	return
 }
 
@@ -98,7 +98,7 @@ func (vk *VK) MarketEditComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.editOrder
 func (vk *VK) MarketEditOrder(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.editOrder", params, &response)
+	err = vk.RequestUnmarshal("market.editOrder", &response, params)
 	return
 }
 
@@ -112,7 +112,7 @@ type MarketGetResponse struct {
 //
 // https://vk.com/dev/market.get
 func (vk *VK) MarketGet(params Params) (response MarketGetResponse, err error) {
-	err = vk.RequestUnmarshal("market.get", params, &response)
+	err = vk.RequestUnmarshal("market.get", &response, params)
 	return
 }
 
@@ -126,7 +126,7 @@ type MarketGetAlbumByIDResponse struct {
 //
 // https://vk.com/dev/market.getAlbumById
 func (vk *VK) MarketGetAlbumByID(params Params) (response MarketGetAlbumByIDResponse, err error) {
-	err = vk.RequestUnmarshal("market.getAlbumById", params, &response)
+	err = vk.RequestUnmarshal("market.getAlbumById", &response, params)
 	return
 }
 
@@ -140,7 +140,7 @@ type MarketGetAlbumsResponse struct {
 //
 // https://vk.com/dev/market.getAlbums
 func (vk *VK) MarketGetAlbums(params Params) (response MarketGetAlbumsResponse, err error) {
-	err = vk.RequestUnmarshal("market.getAlbums", params, &response)
+	err = vk.RequestUnmarshal("market.getAlbums", &response, params)
 	return
 }
 
@@ -154,7 +154,7 @@ type MarketGetByIDResponse struct {
 //
 // https://vk.com/dev/market.getById
 func (vk *VK) MarketGetByID(params Params) (response MarketGetByIDResponse, err error) {
-	err = vk.RequestUnmarshal("market.getById", params, &response)
+	err = vk.RequestUnmarshal("market.getById", &response, params)
 	return
 }
 
@@ -168,7 +168,7 @@ type MarketGetCategoriesResponse struct {
 //
 // https://vk.com/dev/market.getCategories
 func (vk *VK) MarketGetCategories(params Params) (response MarketGetCategoriesResponse, err error) {
-	err = vk.RequestUnmarshal("market.getCategories", params, &response)
+	err = vk.RequestUnmarshal("market.getCategories", &response, params)
 	return
 }
 
@@ -184,8 +184,7 @@ type MarketGetCommentsResponse struct {
 //
 // https://vk.com/dev/market.getComments
 func (vk *VK) MarketGetComments(params Params) (response MarketGetCommentsResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("market.getComments", params, &response)
+	err = vk.RequestUnmarshal("market.getComments", &response, params, Params{"extended": false})
 
 	return
 }
@@ -203,8 +202,7 @@ type MarketGetCommentsExtendedResponse struct {
 //
 // https://vk.com/dev/market.getComments
 func (vk *VK) MarketGetCommentsExtended(params Params) (response MarketGetCommentsExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("market.getComments", params, &response)
+	err = vk.RequestUnmarshal("market.getComments", &response, params, Params{"extended": true})
 
 	return
 }
@@ -219,7 +217,7 @@ type MarketGetGroupOrdersResponse struct {
 //
 // https://vk.com/dev/market.getGroupOrders
 func (vk *VK) MarketGetGroupOrders(params Params) (response MarketGetGroupOrdersResponse, err error) {
-	err = vk.RequestUnmarshal("market.getGroupOrders", params, &response)
+	err = vk.RequestUnmarshal("market.getGroupOrders", &response, params)
 	return
 }
 
@@ -232,7 +230,7 @@ type MarketGetOrderByIDResponse struct {
 //
 // https://vk.com/dev/market.getOrderById
 func (vk *VK) MarketGetOrderByID(params Params) (response MarketGetOrderByIDResponse, err error) {
-	err = vk.RequestUnmarshal("market.getOrderById", params, &response)
+	err = vk.RequestUnmarshal("market.getOrderById", &response, params)
 	return
 }
 
@@ -246,7 +244,7 @@ type MarketGetOrderItemsResponse struct {
 //
 // https://vk.com/dev/market.getOrderItems
 func (vk *VK) MarketGetOrderItems(params Params) (response MarketGetOrderItemsResponse, err error) {
-	err = vk.RequestUnmarshal("market.getOrderItems", params, &response)
+	err = vk.RequestUnmarshal("market.getOrderItems", &response, params)
 	return
 }
 
@@ -254,7 +252,7 @@ func (vk *VK) MarketGetOrderItems(params Params) (response MarketGetOrderItemsRe
 //
 // https://vk.com/dev/market.removeFromAlbum
 func (vk *VK) MarketRemoveFromAlbum(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.removeFromAlbum", params, &response)
+	err = vk.RequestUnmarshal("market.removeFromAlbum", &response, params)
 	return
 }
 
@@ -262,7 +260,7 @@ func (vk *VK) MarketRemoveFromAlbum(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.reorderAlbums
 func (vk *VK) MarketReorderAlbums(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.reorderAlbums", params, &response)
+	err = vk.RequestUnmarshal("market.reorderAlbums", &response, params)
 	return
 }
 
@@ -270,7 +268,7 @@ func (vk *VK) MarketReorderAlbums(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.reorderItems
 func (vk *VK) MarketReorderItems(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.reorderItems", params, &response)
+	err = vk.RequestUnmarshal("market.reorderItems", &response, params)
 	return
 }
 
@@ -278,7 +276,7 @@ func (vk *VK) MarketReorderItems(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.report
 func (vk *VK) MarketReport(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.report", params, &response)
+	err = vk.RequestUnmarshal("market.report", &response, params)
 	return
 }
 
@@ -286,7 +284,7 @@ func (vk *VK) MarketReport(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.reportComment
 func (vk *VK) MarketReportComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.reportComment", params, &response)
+	err = vk.RequestUnmarshal("market.reportComment", &response, params)
 	return
 }
 
@@ -294,7 +292,7 @@ func (vk *VK) MarketReportComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.restore
 func (vk *VK) MarketRestore(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.restore", params, &response)
+	err = vk.RequestUnmarshal("market.restore", &response, params)
 	return
 }
 
@@ -302,7 +300,7 @@ func (vk *VK) MarketRestore(params Params) (response int, err error) {
 //
 // https://vk.com/dev/market.restoreComment
 func (vk *VK) MarketRestoreComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("market.restoreComment", params, &response)
+	err = vk.RequestUnmarshal("market.restoreComment", &response, params)
 	return
 }
 
@@ -316,6 +314,6 @@ type MarketSearchResponse struct {
 //
 // https://vk.com/dev/market.search
 func (vk *VK) MarketSearch(params Params) (response MarketSearchResponse, err error) {
-	err = vk.RequestUnmarshal("market.search", params, &response)
+	err = vk.RequestUnmarshal("market.search", &response, params)
 	return
 }

--- a/api/market_test.go
+++ b/api/market_test.go
@@ -269,7 +269,7 @@ func TestVK_MarketGetCategories(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.MarketGetCategories(api.Params{})
+	res, err := vkUser.MarketGetCategories(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.Count)
 

--- a/api/messages.go
+++ b/api/messages.go
@@ -8,7 +8,7 @@ import (
 //
 // https://vk.com/dev/messages.addChatUser
 func (vk *VK) MessagesAddChatUser(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.addChatUser", params, &response)
+	err = vk.RequestUnmarshal("messages.addChatUser", &response, params)
 	return
 }
 
@@ -16,7 +16,7 @@ func (vk *VK) MessagesAddChatUser(params Params) (response int, err error) {
 //
 // https://vk.com/dev/messages.allowMessagesFromGroup
 func (vk *VK) MessagesAllowMessagesFromGroup(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.allowMessagesFromGroup", params, &response)
+	err = vk.RequestUnmarshal("messages.allowMessagesFromGroup", &response, params)
 	return
 }
 
@@ -24,7 +24,7 @@ func (vk *VK) MessagesAllowMessagesFromGroup(params Params) (response int, err e
 //
 // https://vk.com/dev/messages.createChat
 func (vk *VK) MessagesCreateChat(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.createChat", params, &response)
+	err = vk.RequestUnmarshal("messages.createChat", &response, params)
 	return
 }
 
@@ -35,7 +35,7 @@ type MessagesDeleteResponse map[string]int
 //
 // https://vk.com/dev/messages.delete
 func (vk *VK) MessagesDelete(params Params) (response MessagesDeleteResponse, err error) {
-	err = vk.RequestUnmarshal("messages.delete", params, &response)
+	err = vk.RequestUnmarshal("messages.delete", &response, params)
 	return
 }
 
@@ -49,7 +49,7 @@ type MessagesDeleteChatPhotoResponse struct {
 //
 // https://vk.com/dev/messages.deleteChatPhoto
 func (vk *VK) MessagesDeleteChatPhoto(params Params) (response MessagesDeleteChatPhotoResponse, err error) {
-	err = vk.RequestUnmarshal("messages.deleteChatPhoto", params, &response)
+	err = vk.RequestUnmarshal("messages.deleteChatPhoto", &response, params)
 	return
 }
 
@@ -62,7 +62,7 @@ type MessagesDeleteConversationResponse struct {
 //
 // https://vk.com/dev/messages.deleteConversation
 func (vk *VK) MessagesDeleteConversation(params Params) (response MessagesDeleteConversationResponse, err error) {
-	err = vk.RequestUnmarshal("messages.deleteConversation", params, &response)
+	err = vk.RequestUnmarshal("messages.deleteConversation", &response, params)
 	return
 }
 
@@ -70,7 +70,7 @@ func (vk *VK) MessagesDeleteConversation(params Params) (response MessagesDelete
 //
 // https://vk.com/dev/messages.denyMessagesFromGroup
 func (vk *VK) MessagesDenyMessagesFromGroup(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.denyMessagesFromGroup", params, &response)
+	err = vk.RequestUnmarshal("messages.denyMessagesFromGroup", &response, params)
 	return
 }
 
@@ -78,7 +78,7 @@ func (vk *VK) MessagesDenyMessagesFromGroup(params Params) (response int, err er
 //
 // https://vk.com/dev/messages.edit
 func (vk *VK) MessagesEdit(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.edit", params, &response)
+	err = vk.RequestUnmarshal("messages.edit", &response, params)
 	return
 }
 
@@ -86,7 +86,7 @@ func (vk *VK) MessagesEdit(params Params) (response int, err error) {
 //
 // https://vk.com/dev/messages.editChat
 func (vk *VK) MessagesEditChat(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.editChat", params, &response)
+	err = vk.RequestUnmarshal("messages.editChat", &response, params)
 	return
 }
 
@@ -104,7 +104,7 @@ func (vk *VK) MessagesGetByConversationMessageID(params Params) (
 	response MessagesGetByConversationMessageIDResponse,
 	err error,
 ) {
-	err = vk.RequestUnmarshal("messages.getByConversationMessageId", params, &response)
+	err = vk.RequestUnmarshal("messages.getByConversationMessageId", &response, params)
 	return
 }
 
@@ -120,8 +120,7 @@ type MessagesGetByIDResponse struct {
 //
 // https://vk.com/dev/messages.getById
 func (vk *VK) MessagesGetByID(params Params) (response MessagesGetByIDResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("messages.getById", params, &response)
+	err = vk.RequestUnmarshal("messages.getById", &response, params, Params{"extended": false})
 
 	return
 }
@@ -139,8 +138,7 @@ type MessagesGetByIDExtendedResponse struct {
 //
 // https://vk.com/dev/messages.getById
 func (vk *VK) MessagesGetByIDExtended(params Params) (response MessagesGetByIDExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("messages.getById", params, &response)
+	err = vk.RequestUnmarshal("messages.getById", &response, params, Params{"extended": true})
 
 	return
 }
@@ -152,7 +150,7 @@ type MessagesGetChatResponse object.MessagesChat
 //
 // https://vk.com/dev/messages.getChat
 func (vk *VK) MessagesGetChat(params Params) (response MessagesGetChatResponse, err error) {
-	err = vk.RequestUnmarshal("messages.getChat", params, &response)
+	err = vk.RequestUnmarshal("messages.getChat", &response, params)
 	return
 }
 
@@ -163,7 +161,7 @@ type MessagesGetChatChatIDsResponse []object.MessagesChat
 //
 // https://vk.com/dev/messages.getChat
 func (vk *VK) MessagesGetChatChatIDs(params Params) (response MessagesGetChatChatIDsResponse, err error) {
-	err = vk.RequestUnmarshal("messages.getChat", params, &response)
+	err = vk.RequestUnmarshal("messages.getChat", &response, params)
 	return
 }
 
@@ -177,7 +175,7 @@ type MessagesGetChatPreviewResponse struct {
 //
 // https://vk.com/dev/messages.getChatPreview
 func (vk *VK) MessagesGetChatPreview(params Params) (response MessagesGetChatPreviewResponse, err error) {
-	err = vk.RequestUnmarshal("messages.getChatPreview", params, &response)
+	err = vk.RequestUnmarshal("messages.getChatPreview", &response, params)
 	return
 }
 
@@ -208,7 +206,7 @@ func (vk *VK) MessagesGetConversationMembers(params Params) (
 	response MessagesGetConversationMembersResponse,
 	err error,
 ) {
-	err = vk.RequestUnmarshal("messages.getConversationMembers", params, &response)
+	err = vk.RequestUnmarshal("messages.getConversationMembers", &response, params)
 	return
 }
 
@@ -224,7 +222,7 @@ type MessagesGetConversationsResponse struct {
 //
 // https://vk.com/dev/messages.getConversations
 func (vk *VK) MessagesGetConversations(params Params) (response MessagesGetConversationsResponse, err error) {
-	err = vk.RequestUnmarshal("messages.getConversations", params, &response)
+	err = vk.RequestUnmarshal("messages.getConversations", &response, params)
 	return
 }
 
@@ -240,8 +238,7 @@ type MessagesGetConversationsByIDResponse struct {
 //
 // https://vk.com/dev/messages.getConversationsById
 func (vk *VK) MessagesGetConversationsByID(params Params) (response MessagesGetConversationsByIDResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("messages.getConversationsById", params, &response)
+	err = vk.RequestUnmarshal("messages.getConversationsById", &response, params, Params{"extended": false})
 
 	return
 }
@@ -262,8 +259,7 @@ func (vk *VK) MessagesGetConversationsByIDExtended(params Params) (
 	response MessagesGetConversationsByIDExtendedResponse,
 	err error,
 ) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("messages.getConversationsById", params, &response)
+	err = vk.RequestUnmarshal("messages.getConversationsById", &response, params, Params{"extended": true})
 
 	return
 }
@@ -281,7 +277,7 @@ type MessagesGetHistoryResponse struct {
 //
 // https://vk.com/dev/messages.getHistory
 func (vk *VK) MessagesGetHistory(params Params) (response MessagesGetHistoryResponse, err error) {
-	err = vk.RequestUnmarshal("messages.getHistory", params, &response)
+	err = vk.RequestUnmarshal("messages.getHistory", &response, params)
 	return
 }
 
@@ -296,7 +292,7 @@ type MessagesGetHistoryAttachmentsResponse struct {
 //
 // https://vk.com/dev/messages.getHistoryAttachments
 func (vk *VK) MessagesGetHistoryAttachments(params Params) (response MessagesGetHistoryAttachmentsResponse, err error) {
-	err = vk.RequestUnmarshal("messages.getHistoryAttachments", params, &response)
+	err = vk.RequestUnmarshal("messages.getHistoryAttachments", &response, params)
 	return
 }
 
@@ -314,7 +310,7 @@ type MessagesGetImportantMessagesResponse struct {
 //
 // https://vk.com/dev/messages.getImportantMessages
 func (vk *VK) MessagesGetImportantMessages(params Params) (response MessagesGetImportantMessagesResponse, err error) {
-	err = vk.RequestUnmarshal("messages.getImportantMessages", params, &response)
+	err = vk.RequestUnmarshal("messages.getImportantMessages", &response, params)
 	return
 }
 
@@ -327,7 +323,7 @@ type MessagesGetInviteLinkResponse struct {
 //
 // https://vk.com/dev/messages.getInviteLink
 func (vk *VK) MessagesGetInviteLink(params Params) (response MessagesGetInviteLinkResponse, err error) {
-	err = vk.RequestUnmarshal("messages.getInviteLink", params, &response)
+	err = vk.RequestUnmarshal("messages.getInviteLink", &response, params)
 	return
 }
 
@@ -338,7 +334,7 @@ type MessagesGetLastActivityResponse object.MessagesLastActivity
 //
 // https://vk.com/dev/messages.getLastActivity
 func (vk *VK) MessagesGetLastActivity(params Params) (response MessagesGetLastActivityResponse, err error) {
-	err = vk.RequestUnmarshal("messages.getLastActivity", params, &response)
+	err = vk.RequestUnmarshal("messages.getLastActivity", &response, params)
 	return
 }
 
@@ -362,7 +358,7 @@ type MessagesGetLongPollHistoryResponse struct {
 //
 // https://vk.com/dev/messages.getLongPollHistory
 func (vk *VK) MessagesGetLongPollHistory(params Params) (response MessagesGetLongPollHistoryResponse, err error) {
-	err = vk.RequestUnmarshal("messages.getLongPollHistory", params, &response)
+	err = vk.RequestUnmarshal("messages.getLongPollHistory", &response, params)
 	return
 }
 
@@ -373,7 +369,7 @@ type MessagesGetLongPollServerResponse object.MessagesLongpollParams
 //
 // https://vk.com/dev/messages.getLongPollServer
 func (vk *VK) MessagesGetLongPollServer(params Params) (response MessagesGetLongPollServerResponse, err error) {
-	err = vk.RequestUnmarshal("messages.getLongPollServer", params, &response)
+	err = vk.RequestUnmarshal("messages.getLongPollServer", &response, params)
 	return
 }
 
@@ -390,7 +386,7 @@ func (vk *VK) MessagesIsMessagesFromGroupAllowed(params Params) (
 	response MessagesIsMessagesFromGroupAllowedResponse,
 	err error,
 ) {
-	err = vk.RequestUnmarshal("messages.isMessagesFromGroupAllowed", params, &response)
+	err = vk.RequestUnmarshal("messages.isMessagesFromGroupAllowed", &response, params)
 	return
 }
 
@@ -403,7 +399,7 @@ type MessagesJoinChatByInviteLinkResponse struct {
 //
 // https://vk.com/dev/messages.joinChatByInviteLink
 func (vk *VK) MessagesJoinChatByInviteLink(params Params) (response MessagesJoinChatByInviteLinkResponse, err error) {
-	err = vk.RequestUnmarshal("messages.joinChatByInviteLink", params, &response)
+	err = vk.RequestUnmarshal("messages.joinChatByInviteLink", &response, params)
 	return
 }
 
@@ -411,7 +407,7 @@ func (vk *VK) MessagesJoinChatByInviteLink(params Params) (response MessagesJoin
 //
 // https://vk.com/dev/messages.markAsAnsweredConversation
 func (vk *VK) MessagesMarkAsAnsweredConversation(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.markAsAnsweredConversation", params, &response)
+	err = vk.RequestUnmarshal("messages.markAsAnsweredConversation", &response, params)
 	return
 }
 
@@ -422,7 +418,7 @@ type MessagesMarkAsImportantResponse []int
 //
 // https://vk.com/dev/messages.markAsImportant
 func (vk *VK) MessagesMarkAsImportant(params Params) (response MessagesMarkAsImportantResponse, err error) {
-	err = vk.RequestUnmarshal("messages.markAsImportant", params, &response)
+	err = vk.RequestUnmarshal("messages.markAsImportant", &response, params)
 	return
 }
 
@@ -430,7 +426,7 @@ func (vk *VK) MessagesMarkAsImportant(params Params) (response MessagesMarkAsImp
 //
 // https://vk.com/dev/messages.markAsImportantConversation
 func (vk *VK) MessagesMarkAsImportantConversation(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.markAsImportantConversation", params, &response)
+	err = vk.RequestUnmarshal("messages.markAsImportantConversation", &response, params)
 	return
 }
 
@@ -438,7 +434,7 @@ func (vk *VK) MessagesMarkAsImportantConversation(params Params) (response int, 
 //
 // https://vk.com/dev/messages.markAsRead
 func (vk *VK) MessagesMarkAsRead(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.markAsRead", params, &response)
+	err = vk.RequestUnmarshal("messages.markAsRead", &response, params)
 	return
 }
 
@@ -449,7 +445,7 @@ type MessagesPinResponse object.MessagesMessage
 //
 // https://vk.com/dev/messages.pin
 func (vk *VK) MessagesPin(params Params) (response MessagesPinResponse, err error) {
-	err = vk.RequestUnmarshal("messages.pin", params, &response)
+	err = vk.RequestUnmarshal("messages.pin", &response, params)
 	return
 }
 
@@ -459,7 +455,7 @@ func (vk *VK) MessagesPin(params Params) (response MessagesPinResponse, err erro
 //
 // https://vk.com/dev/messages.removeChatUser
 func (vk *VK) MessagesRemoveChatUser(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.removeChatUser", params, &response)
+	err = vk.RequestUnmarshal("messages.removeChatUser", &response, params)
 	return
 }
 
@@ -467,7 +463,7 @@ func (vk *VK) MessagesRemoveChatUser(params Params) (response int, err error) {
 //
 // https://vk.com/dev/messages.restore
 func (vk *VK) MessagesRestore(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.restore", params, &response)
+	err = vk.RequestUnmarshal("messages.restore", &response, params)
 	return
 }
 
@@ -483,7 +479,7 @@ type MessagesSearchResponse struct {
 //
 // https://vk.com/dev/messages.search
 func (vk *VK) MessagesSearch(params Params) (response MessagesSearchResponse, err error) {
-	err = vk.RequestUnmarshal("messages.search", params, &response)
+	err = vk.RequestUnmarshal("messages.search", &response, params)
 	return
 }
 
@@ -498,7 +494,7 @@ type MessagesSearchConversationsResponse struct {
 //
 // https://vk.com/dev/messages.searchConversations
 func (vk *VK) MessagesSearchConversations(params Params) (response MessagesSearchConversationsResponse, err error) {
-	err = vk.RequestUnmarshal("messages.searchConversations", params, &response)
+	err = vk.RequestUnmarshal("messages.searchConversations", &response, params)
 	return
 }
 
@@ -508,9 +504,12 @@ func (vk *VK) MessagesSearchConversations(params Params) (response MessagesSearc
 //
 // https://vk.com/dev/messages.send
 func (vk *VK) MessagesSend(params Params) (response int, err error) {
-	params["user_ids"] = ""
-	params["peer_ids"] = ""
-	err = vk.RequestUnmarshal("messages.send", params, &response)
+	reqParams := Params{
+		"user_ids": "",
+		"peer_ids": "",
+	}
+
+	err = vk.RequestUnmarshal("messages.send", &response, params, reqParams)
 
 	return
 }
@@ -531,7 +530,7 @@ type MessagesSendUserIDsResponse []struct {
 //
 // https://vk.com/dev/messages.send
 func (vk *VK) MessagesSendUserIDs(params Params) (response MessagesSendUserIDsResponse, err error) {
-	err = vk.RequestUnmarshal("messages.send", params, &response)
+	err = vk.RequestUnmarshal("messages.send", &response, params)
 	return
 }
 
@@ -539,7 +538,7 @@ func (vk *VK) MessagesSendUserIDs(params Params) (response MessagesSendUserIDsRe
 //
 // https://vk.com/dev/messages.sendMessageEventAnswer
 func (vk *VK) MessagesSendMessageEventAnswer(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.sendMessageEventAnswer", params, &response)
+	err = vk.RequestUnmarshal("messages.sendMessageEventAnswer", &response, params)
 	return
 }
 
@@ -547,8 +546,7 @@ func (vk *VK) MessagesSendMessageEventAnswer(params Params) (response int, err e
 //
 // https://vk.com/dev/messages.sendSticker
 func (vk *VK) MessagesSendSticker(params Params) (response int, err error) {
-	params["user_ids"] = ""
-	err = vk.RequestUnmarshal("messages.sendSticker", params, &response)
+	err = vk.RequestUnmarshal("messages.sendSticker", &response, params, Params{"user_ids": ""})
 
 	return
 }
@@ -557,7 +555,7 @@ func (vk *VK) MessagesSendSticker(params Params) (response int, err error) {
 //
 // https://vk.com/dev/messages.setActivity
 func (vk *VK) MessagesSetActivity(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.setActivity", params, &response)
+	err = vk.RequestUnmarshal("messages.setActivity", &response, params)
 	return
 }
 
@@ -571,7 +569,7 @@ type MessagesSetChatPhotoResponse struct {
 //
 // https://vk.com/dev/messages.setChatPhoto
 func (vk *VK) MessagesSetChatPhoto(params Params) (response MessagesSetChatPhotoResponse, err error) {
-	err = vk.RequestUnmarshal("messages.setChatPhoto", params, &response)
+	err = vk.RequestUnmarshal("messages.setChatPhoto", &response, params)
 	return
 }
 
@@ -579,6 +577,6 @@ func (vk *VK) MessagesSetChatPhoto(params Params) (response MessagesSetChatPhoto
 //
 // https://vk.com/dev/messages.unpin
 func (vk *VK) MessagesUnpin(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("messages.unpin", params, &response)
+	err = vk.RequestUnmarshal("messages.unpin", &response, params)
 	return
 }

--- a/api/messages_test.go
+++ b/api/messages_test.go
@@ -227,7 +227,7 @@ func TestVK_MessagesGetConversations(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.MessagesGetConversations(api.Params{})
+	res, err := vkUser.MessagesGetConversations(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.Count)
 
@@ -302,7 +302,7 @@ func TestVK_MessagesGetImportantMessages(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.MessagesGetImportantMessages(api.Params{})
+	_, err := vkUser.MessagesGetImportantMessages(nil)
 	noError(t, err)
 }
 
@@ -450,7 +450,7 @@ func TestVK_MessagesSearchConversations(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.MessagesSearchConversations(api.Params{})
+	_, err := vkUser.MessagesSearchConversations(nil)
 	noError(t, err)
 }
 

--- a/api/newsfeed.go
+++ b/api/newsfeed.go
@@ -9,7 +9,7 @@ import (
 //
 // https://vk.com/dev/newsfeed.addBan
 func (vk *VK) NewsfeedAddBan(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("newsfeed.addBan", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.addBan", &response, params)
 	return
 }
 
@@ -18,7 +18,7 @@ func (vk *VK) NewsfeedAddBan(params Params) (response int, err error) {
 //
 // https://vk.com/dev/newsfeed.deleteBan
 func (vk *VK) NewsfeedDeleteBan(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("newsfeed.deleteBan", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.deleteBan", &response, params)
 	return
 }
 
@@ -26,7 +26,7 @@ func (vk *VK) NewsfeedDeleteBan(params Params) (response int, err error) {
 //
 // https://vk.com/dev/newsfeed.deleteList
 func (vk *VK) NewsfeedDeleteList(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("newsfeed.deleteList", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.deleteList", &response, params)
 	return
 }
 
@@ -41,7 +41,7 @@ type NewsfeedGetResponse struct {
 //
 // https://vk.com/dev/newsfeed.get
 func (vk *VK) NewsfeedGet(params Params) (response NewsfeedGetResponse, err error) {
-	err = vk.RequestUnmarshal("newsfeed.get", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.get", &response, params)
 	return
 }
 
@@ -57,8 +57,7 @@ type NewsfeedGetBannedResponse struct {
 //
 // https://vk.com/dev/newsfeed.getBanned
 func (vk *VK) NewsfeedGetBanned(params Params) (response NewsfeedGetBannedResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("newsfeed.getBanned", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.getBanned", &response, params, Params{"extended": false})
 
 	return
 }
@@ -74,8 +73,7 @@ type NewsfeedGetBannedExtendedResponse struct {
 //
 // https://vk.com/dev/newsfeed.getBanned
 func (vk *VK) NewsfeedGetBannedExtended(params Params) (response NewsfeedGetBannedExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("newsfeed.getBanned", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.getBanned", &response, params, Params{"extended": true})
 
 	return
 }
@@ -91,7 +89,7 @@ type NewsfeedGetCommentsResponse struct {
 //
 // https://vk.com/dev/newsfeed.getComments
 func (vk *VK) NewsfeedGetComments(params Params) (response NewsfeedGetCommentsResponse, err error) {
-	err = vk.RequestUnmarshal("newsfeed.getComments", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.getComments", &response, params)
 	return
 }
 
@@ -110,7 +108,7 @@ type NewsfeedGetListsResponse struct {
 //
 // https://vk.com/dev/newsfeed.getLists
 func (vk *VK) NewsfeedGetLists(params Params) (response NewsfeedGetListsResponse, err error) {
-	err = vk.RequestUnmarshal("newsfeed.getLists", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.getLists", &response, params)
 	return
 }
 
@@ -124,7 +122,7 @@ type NewsfeedGetMentionsResponse struct {
 //
 // https://vk.com/dev/newsfeed.getMentions
 func (vk *VK) NewsfeedGetMentions(params Params) (response NewsfeedGetMentionsResponse, err error) {
-	err = vk.RequestUnmarshal("newsfeed.getMentions", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.getMentions", &response, params)
 	return
 }
 
@@ -141,7 +139,7 @@ type NewsfeedGetRecommendedResponse struct {
 //
 // https://vk.com/dev/newsfeed.getRecommended
 func (vk *VK) NewsfeedGetRecommended(params Params) (response NewsfeedGetRecommendedResponse, err error) {
-	err = vk.RequestUnmarshal("newsfeed.getRecommended", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.getRecommended", &response, params)
 	return
 }
 
@@ -155,7 +153,7 @@ type NewsfeedGetSuggestedSourcesResponse struct {
 //
 // https://vk.com/dev/newsfeed.getSuggestedSources
 func (vk *VK) NewsfeedGetSuggestedSources(params Params) (response NewsfeedGetSuggestedSourcesResponse, err error) {
-	err = vk.RequestUnmarshal("newsfeed.getSuggestedSources", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.getSuggestedSources", &response, params)
 	return
 }
 
@@ -163,7 +161,7 @@ func (vk *VK) NewsfeedGetSuggestedSources(params Params) (response NewsfeedGetSu
 //
 // https://vk.com/dev/newsfeed.ignoreItem
 func (vk *VK) NewsfeedIgnoreItem(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("newsfeed.ignoreItem", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.ignoreItem", &response, params)
 	return
 }
 
@@ -171,7 +169,7 @@ func (vk *VK) NewsfeedIgnoreItem(params Params) (response int, err error) {
 //
 // https://vk.com/dev/newsfeed.saveList
 func (vk *VK) NewsfeedSaveList(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("newsfeed.saveList", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.saveList", &response, params)
 	return
 }
 
@@ -189,8 +187,7 @@ type NewsfeedSearchResponse struct {
 //
 // https://vk.com/dev/newsfeed.search
 func (vk *VK) NewsfeedSearch(params Params) (response NewsfeedSearchResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("newsfeed.search", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.search", &response, params, Params{"extended": false})
 
 	return
 }
@@ -211,8 +208,7 @@ type NewsfeedSearchExtendedResponse struct {
 //
 // https://vk.com/dev/newsfeed.search
 func (vk *VK) NewsfeedSearchExtended(params Params) (response NewsfeedSearchExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("newsfeed.search", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.search", &response, params, Params{"extended": true})
 
 	return
 }
@@ -221,7 +217,7 @@ func (vk *VK) NewsfeedSearchExtended(params Params) (response NewsfeedSearchExte
 //
 // https://vk.com/dev/newsfeed.unignoreItem
 func (vk *VK) NewsfeedUnignoreItem(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("newsfeed.unignoreItem", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.unignoreItem", &response, params)
 	return
 }
 
@@ -229,6 +225,6 @@ func (vk *VK) NewsfeedUnignoreItem(params Params) (response int, err error) {
 //
 // https://vk.com/dev/newsfeed.unsubscribe
 func (vk *VK) NewsfeedUnsubscribe(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("newsfeed.unsubscribe", params, &response)
+	err = vk.RequestUnmarshal("newsfeed.unsubscribe", &response, params)
 	return
 }

--- a/api/newsfeed_test.go
+++ b/api/newsfeed_test.go
@@ -18,12 +18,12 @@ func TestVK_NewsfeedAddBan(t *testing.T) {
 	})
 	noError(t, err)
 
-	banned, err := vkUser.NewsfeedGetBanned(api.Params{})
+	banned, err := vkUser.NewsfeedGetBanned(nil)
 	noError(t, err)
 	assert.NotEmpty(t, banned.Groups)
 	assert.NotEmpty(t, banned.Members)
 
-	bannedEx, err := vkUser.NewsfeedGetBannedExtended(api.Params{})
+	bannedEx, err := vkUser.NewsfeedGetBannedExtended(nil)
 	noError(t, err)
 	assert.NotEmpty(t, bannedEx.Groups)
 	assert.NotEmpty(t, bannedEx.Profiles)
@@ -40,7 +40,7 @@ func TestVK_NewsfeedGet(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.NewsfeedGet(api.Params{})
+	res, err := vkUser.NewsfeedGet(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.Items)
 	assert.NotEmpty(t, res.Profiles)
@@ -81,7 +81,7 @@ func TestVK_NewsfeedGetRecommended(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.NewsfeedGetRecommended(api.Params{})
+	res, err := vkUser.NewsfeedGetRecommended(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.Items)
 	assert.NotEmpty(t, res.Profiles)
@@ -93,7 +93,7 @@ func TestVK_NewsfeedGetSuggestedSources(t *testing.T) {
 	// FIXME: NewsfeedGetSuggestedSources have bug
 	// needUserToken(t)
 
-	// res, err := vkUser.NewsfeedGetSuggestedSources(api.Params{})
+	// res, err := vkUser.NewsfeedGetSuggestedSources(nil)
 	// noError(t, err)
 	// assert.NotEmpty(t, res.Count)
 	// assert.NotEmpty(t, res.Items)

--- a/api/notes.go
+++ b/api/notes.go
@@ -8,7 +8,7 @@ import (
 //
 // https://vk.com/dev/notes.add
 func (vk *VK) NotesAdd(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("notes.add", params, &response)
+	err = vk.RequestUnmarshal("notes.add", &response, params)
 	return
 }
 
@@ -16,7 +16,7 @@ func (vk *VK) NotesAdd(params Params) (response int, err error) {
 //
 // https://vk.com/dev/notes.createComment
 func (vk *VK) NotesCreateComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("notes.createComment", params, &response)
+	err = vk.RequestUnmarshal("notes.createComment", &response, params)
 	return
 }
 
@@ -24,7 +24,7 @@ func (vk *VK) NotesCreateComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/notes.delete
 func (vk *VK) NotesDelete(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("notes.delete", params, &response)
+	err = vk.RequestUnmarshal("notes.delete", &response, params)
 	return
 }
 
@@ -32,7 +32,7 @@ func (vk *VK) NotesDelete(params Params) (response int, err error) {
 //
 // https://vk.com/dev/notes.deleteComment
 func (vk *VK) NotesDeleteComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("notes.deleteComment", params, &response)
+	err = vk.RequestUnmarshal("notes.deleteComment", &response, params)
 	return
 }
 
@@ -40,7 +40,7 @@ func (vk *VK) NotesDeleteComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/notes.edit
 func (vk *VK) NotesEdit(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("notes.edit", params, &response)
+	err = vk.RequestUnmarshal("notes.edit", &response, params)
 	return
 }
 
@@ -48,7 +48,7 @@ func (vk *VK) NotesEdit(params Params) (response int, err error) {
 //
 // https://vk.com/dev/notes.editComment
 func (vk *VK) NotesEditComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("notes.editComment", params, &response)
+	err = vk.RequestUnmarshal("notes.editComment", &response, params)
 	return
 }
 
@@ -62,7 +62,7 @@ type NotesGetResponse struct {
 //
 // https://vk.com/dev/notes.get
 func (vk *VK) NotesGet(params Params) (response NotesGetResponse, err error) {
-	err = vk.RequestUnmarshal("notes.get", params, &response)
+	err = vk.RequestUnmarshal("notes.get", &response, params)
 	return
 }
 
@@ -73,7 +73,7 @@ type NotesGetByIDResponse object.NotesNote
 //
 // https://vk.com/dev/notes.getById
 func (vk *VK) NotesGetByID(params Params) (response NotesGetByIDResponse, err error) {
-	err = vk.RequestUnmarshal("notes.getById", params, &response)
+	err = vk.RequestUnmarshal("notes.getById", &response, params)
 	return
 }
 
@@ -87,7 +87,7 @@ type NotesGetCommentsResponse struct {
 //
 // https://vk.com/dev/notes.getComments
 func (vk *VK) NotesGetComments(params Params) (response NotesGetCommentsResponse, err error) {
-	err = vk.RequestUnmarshal("notes.getComments", params, &response)
+	err = vk.RequestUnmarshal("notes.getComments", &response, params)
 	return
 }
 
@@ -95,6 +95,6 @@ func (vk *VK) NotesGetComments(params Params) (response NotesGetCommentsResponse
 //
 // https://vk.com/dev/notes.restoreComment
 func (vk *VK) NotesRestoreComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("notes.restoreComment", params, &response)
+	err = vk.RequestUnmarshal("notes.restoreComment", &response, params)
 	return
 }

--- a/api/notifications.go
+++ b/api/notifications.go
@@ -22,7 +22,7 @@ type NotificationsGetResponse struct {
 //
 // https://vk.com/dev/notifications.get
 func (vk *VK) NotificationsGet(params Params) (response NotificationsGetResponse, err error) {
-	err = vk.RequestUnmarshal("notifications.get", params, &response)
+	err = vk.RequestUnmarshal("notifications.get", &response, params)
 	return
 }
 
@@ -31,7 +31,7 @@ func (vk *VK) NotificationsGet(params Params) (response NotificationsGetResponse
 //
 // https://vk.com/dev/notifications.markAsViewed
 func (vk *VK) NotificationsMarkAsViewed(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("notifications.markAsViewed", params, &response)
+	err = vk.RequestUnmarshal("notifications.markAsViewed", &response, params)
 	return
 }
 
@@ -49,6 +49,6 @@ type NotificationsSendMessageResponse []struct {
 //
 // https://vk.com/dev/notifications.sendMessage
 func (vk *VK) NotificationsSendMessage(params Params) (response NotificationsSendMessageResponse, err error) {
-	err = vk.RequestUnmarshal("notifications.sendMessage", params, &response)
+	err = vk.RequestUnmarshal("notifications.sendMessage", &response, params)
 	return
 }

--- a/api/notifications_test.go
+++ b/api/notifications_test.go
@@ -28,7 +28,7 @@ func TestVK_NotificationsMarkAsViewed(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.NotificationsMarkAsViewed(api.Params{})
+	res, err := vkUser.NotificationsMarkAsViewed(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res)
 }

--- a/api/orders.go
+++ b/api/orders.go
@@ -8,7 +8,7 @@ import (
 //
 // https://vk.com/dev/orders.cancelSubscription
 func (vk *VK) OrdersCancelSubscription(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("orders.cancelSubscription", params, &response)
+	err = vk.RequestUnmarshal("orders.cancelSubscription", &response, params)
 	return
 }
 
@@ -19,7 +19,7 @@ type OrdersChangeStateResponse string // New state
 //
 // https://vk.com/dev/orders.changeState
 func (vk *VK) OrdersChangeState(params Params) (response OrdersChangeStateResponse, err error) {
-	err = vk.RequestUnmarshal("orders.changeState", params, &response)
+	err = vk.RequestUnmarshal("orders.changeState", &response, params)
 	return
 }
 
@@ -30,7 +30,7 @@ type OrdersGetResponse []object.OrdersOrder
 //
 // https://vk.com/dev/orders.get
 func (vk *VK) OrdersGet(params Params) (response OrdersGetResponse, err error) {
-	err = vk.RequestUnmarshal("orders.get", params, &response)
+	err = vk.RequestUnmarshal("orders.get", &response, params)
 	return
 }
 
@@ -41,7 +41,7 @@ type OrdersGetAmountResponse []object.OrdersAmount
 //
 // https://vk.com/dev/orders.getAmount
 func (vk *VK) OrdersGetAmount(params Params) (response OrdersGetAmountResponse, err error) {
-	err = vk.RequestUnmarshal("orders.getAmount", params, &response)
+	err = vk.RequestUnmarshal("orders.getAmount", &response, params)
 	return
 }
 
@@ -52,7 +52,7 @@ type OrdersGetByIDResponse []object.OrdersOrder
 //
 // https://vk.com/dev/orders.getByID
 func (vk *VK) OrdersGetByID(params Params) (response OrdersGetByIDResponse, err error) {
-	err = vk.RequestUnmarshal("orders.getById", params, &response)
+	err = vk.RequestUnmarshal("orders.getById", &response, params)
 	return
 }
 
@@ -63,7 +63,7 @@ type OrdersGetUserSubscriptionByIDResponse object.OrdersSubscription
 //
 // https://vk.com/dev/orders.getUserSubscriptionById
 func (vk *VK) OrdersGetUserSubscriptionByID(params Params) (response OrdersGetUserSubscriptionByIDResponse, err error) {
-	err = vk.RequestUnmarshal("orders.getUserSubscriptionById", params, &response)
+	err = vk.RequestUnmarshal("orders.getUserSubscriptionById", &response, params)
 	return
 }
 
@@ -77,7 +77,7 @@ type OrdersGetUserSubscriptionsResponse struct {
 //
 // https://vk.com/dev/orders.getUserSubscriptions
 func (vk *VK) OrdersGetUserSubscriptions(params Params) (response OrdersGetUserSubscriptionsResponse, err error) {
-	err = vk.RequestUnmarshal("orders.getUserSubscriptions", params, &response)
+	err = vk.RequestUnmarshal("orders.getUserSubscriptions", &response, params)
 	return
 }
 
@@ -85,6 +85,6 @@ func (vk *VK) OrdersGetUserSubscriptions(params Params) (response OrdersGetUserS
 //
 // https://vk.com/dev/orders.updateSubscription
 func (vk *VK) OrdersUpdateSubscription(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("orders.updateSubscription", params, &response)
+	err = vk.RequestUnmarshal("orders.updateSubscription", &response, params)
 	return
 }

--- a/api/pages.go
+++ b/api/pages.go
@@ -8,7 +8,7 @@ import (
 //
 // https://vk.com/dev/pages.clearCache
 func (vk *VK) PagesClearCache(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("pages.clearCache", params, &response)
+	err = vk.RequestUnmarshal("pages.clearCache", &response, params)
 	return
 }
 
@@ -19,7 +19,7 @@ type PagesGetResponse object.PagesWikipageFull
 //
 // https://vk.com/dev/pages.get
 func (vk *VK) PagesGet(params Params) (response PagesGetResponse, err error) {
-	err = vk.RequestUnmarshal("pages.get", params, &response)
+	err = vk.RequestUnmarshal("pages.get", &response, params)
 	return
 }
 
@@ -30,7 +30,7 @@ type PagesGetHistoryResponse []object.PagesWikipageHistory
 //
 // https://vk.com/dev/pages.getHistory
 func (vk *VK) PagesGetHistory(params Params) (response PagesGetHistoryResponse, err error) {
-	err = vk.RequestUnmarshal("pages.getHistory", params, &response)
+	err = vk.RequestUnmarshal("pages.getHistory", &response, params)
 	return
 }
 
@@ -41,7 +41,7 @@ type PagesGetTitlesResponse []object.PagesWikipageFull
 //
 // https://vk.com/dev/pages.getTitles
 func (vk *VK) PagesGetTitles(params Params) (response PagesGetTitlesResponse, err error) {
-	err = vk.RequestUnmarshal("pages.getTitles", params, &response)
+	err = vk.RequestUnmarshal("pages.getTitles", &response, params)
 	return
 }
 
@@ -52,7 +52,7 @@ type PagesGetVersionResponse object.PagesWikipageFull
 //
 // https://vk.com/dev/pages.getVersion
 func (vk *VK) PagesGetVersion(params Params) (response PagesGetVersionResponse, err error) {
-	err = vk.RequestUnmarshal("pages.getVersion", params, &response)
+	err = vk.RequestUnmarshal("pages.getVersion", &response, params)
 	return
 }
 
@@ -60,7 +60,7 @@ func (vk *VK) PagesGetVersion(params Params) (response PagesGetVersionResponse, 
 //
 // https://vk.com/dev/pages.parseWiki
 func (vk *VK) PagesParseWiki(params Params) (response string, err error) {
-	err = vk.RequestUnmarshal("pages.parseWiki", params, &response)
+	err = vk.RequestUnmarshal("pages.parseWiki", &response, params)
 	return
 }
 
@@ -68,7 +68,7 @@ func (vk *VK) PagesParseWiki(params Params) (response string, err error) {
 //
 // https://vk.com/dev/pages.save
 func (vk *VK) PagesSave(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("pages.save", params, &response)
+	err = vk.RequestUnmarshal("pages.save", &response, params)
 	return
 }
 
@@ -76,6 +76,6 @@ func (vk *VK) PagesSave(params Params) (response int, err error) {
 //
 // https://vk.com/dev/pages.saveAccess
 func (vk *VK) PagesSaveAccess(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("pages.saveAccess", params, &response)
+	err = vk.RequestUnmarshal("pages.saveAccess", &response, params)
 	return
 }

--- a/api/photos.go
+++ b/api/photos.go
@@ -8,7 +8,7 @@ import (
 //
 // https://vk.com/dev/photos.confirmTag
 func (vk *VK) PhotosConfirmTag(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.confirmTag", params, &response)
+	err = vk.RequestUnmarshal("photos.confirmTag", &response, params)
 	return
 }
 
@@ -16,7 +16,7 @@ func (vk *VK) PhotosConfirmTag(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.confirmTags
 func (vk *VK) PhotosConfirmTags(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.confirmTags", params, &response)
+	err = vk.RequestUnmarshal("photos.confirmTags", &response, params)
 	return
 }
 
@@ -24,7 +24,7 @@ func (vk *VK) PhotosConfirmTags(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.copy
 func (vk *VK) PhotosCopy(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.copy", params, &response)
+	err = vk.RequestUnmarshal("photos.copy", &response, params)
 	return
 }
 
@@ -35,7 +35,7 @@ type PhotosCreateAlbumResponse object.PhotosPhotoAlbumFull
 //
 // https://vk.com/dev/photos.createAlbum
 func (vk *VK) PhotosCreateAlbum(params Params) (response PhotosCreateAlbumResponse, err error) {
-	err = vk.RequestUnmarshal("photos.createAlbum", params, &response)
+	err = vk.RequestUnmarshal("photos.createAlbum", &response, params)
 	return
 }
 
@@ -43,7 +43,7 @@ func (vk *VK) PhotosCreateAlbum(params Params) (response PhotosCreateAlbumRespon
 //
 // https://vk.com/dev/photos.createComment
 func (vk *VK) PhotosCreateComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.createComment", params, &response)
+	err = vk.RequestUnmarshal("photos.createComment", &response, params)
 	return
 }
 
@@ -51,7 +51,7 @@ func (vk *VK) PhotosCreateComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.declineTags
 func (vk *VK) PhotosDeclineTags(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.declineTags", params, &response)
+	err = vk.RequestUnmarshal("photos.declineTags", &response, params)
 	return
 }
 
@@ -59,7 +59,7 @@ func (vk *VK) PhotosDeclineTags(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.delete
 func (vk *VK) PhotosDelete(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.delete", params, &response)
+	err = vk.RequestUnmarshal("photos.delete", &response, params)
 	return
 }
 
@@ -67,7 +67,7 @@ func (vk *VK) PhotosDelete(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.deleteAlbum
 func (vk *VK) PhotosDeleteAlbum(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.deleteAlbum", params, &response)
+	err = vk.RequestUnmarshal("photos.deleteAlbum", &response, params)
 	return
 }
 
@@ -75,7 +75,7 @@ func (vk *VK) PhotosDeleteAlbum(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.deleteComment
 func (vk *VK) PhotosDeleteComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.deleteComment", params, &response)
+	err = vk.RequestUnmarshal("photos.deleteComment", &response, params)
 	return
 }
 
@@ -83,7 +83,7 @@ func (vk *VK) PhotosDeleteComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.edit
 func (vk *VK) PhotosEdit(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.edit", params, &response)
+	err = vk.RequestUnmarshal("photos.edit", &response, params)
 	return
 }
 
@@ -91,7 +91,7 @@ func (vk *VK) PhotosEdit(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.editAlbum
 func (vk *VK) PhotosEditAlbum(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.editAlbum", params, &response)
+	err = vk.RequestUnmarshal("photos.editAlbum", &response, params)
 	return
 }
 
@@ -99,7 +99,7 @@ func (vk *VK) PhotosEditAlbum(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.editComment
 func (vk *VK) PhotosEditComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.editComment", params, &response)
+	err = vk.RequestUnmarshal("photos.editComment", &response, params)
 	return
 }
 
@@ -115,8 +115,7 @@ type PhotosGetResponse struct {
 //
 // https://vk.com/dev/photos.get
 func (vk *VK) PhotosGet(params Params) (response PhotosGetResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("photos.get", params, &response)
+	err = vk.RequestUnmarshal("photos.get", &response, params, Params{"extended": false})
 
 	return
 }
@@ -133,8 +132,7 @@ type PhotosGetExtendedResponse struct {
 //
 // https://vk.com/dev/photos.get
 func (vk *VK) PhotosGetExtended(params Params) (response PhotosGetExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("photos.get", params, &response)
+	err = vk.RequestUnmarshal("photos.get", &response, params, Params{"extended": true})
 
 	return
 }
@@ -149,7 +147,7 @@ type PhotosGetAlbumsResponse struct {
 //
 // https://vk.com/dev/photos.getAlbums
 func (vk *VK) PhotosGetAlbums(params Params) (response PhotosGetAlbumsResponse, err error) {
-	err = vk.RequestUnmarshal("photos.getAlbums", params, &response)
+	err = vk.RequestUnmarshal("photos.getAlbums", &response, params)
 	return
 }
 
@@ -157,7 +155,7 @@ func (vk *VK) PhotosGetAlbums(params Params) (response PhotosGetAlbumsResponse, 
 //
 // https://vk.com/dev/photos.getAlbumsCount
 func (vk *VK) PhotosGetAlbumsCount(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.getAlbumsCount", params, &response)
+	err = vk.RequestUnmarshal("photos.getAlbumsCount", &response, params)
 	return
 }
 
@@ -174,8 +172,7 @@ type PhotosGetAllResponse struct {
 //
 // https://vk.com/dev/photos.getAll
 func (vk *VK) PhotosGetAll(params Params) (response PhotosGetAllResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("photos.getAll", params, &response)
+	err = vk.RequestUnmarshal("photos.getAll", &response, params, Params{"extended": false})
 
 	return
 }
@@ -193,8 +190,7 @@ type PhotosGetAllExtendedResponse struct {
 //
 // https://vk.com/dev/photos.getAll
 func (vk *VK) PhotosGetAllExtended(params Params) (response PhotosGetAllExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("photos.getAll", params, &response)
+	err = vk.RequestUnmarshal("photos.getAll", &response, params, Params{"extended": true})
 
 	return
 }
@@ -210,7 +206,7 @@ type PhotosGetAllCommentsResponse struct {
 //
 // https://vk.com/dev/photos.getAllComments
 func (vk *VK) PhotosGetAllComments(params Params) (response PhotosGetAllCommentsResponse, err error) {
-	err = vk.RequestUnmarshal("photos.getAllComments", params, &response)
+	err = vk.RequestUnmarshal("photos.getAllComments", &response, params)
 	return
 }
 
@@ -223,8 +219,7 @@ type PhotosGetByIDResponse []object.PhotosPhoto
 //
 // https://vk.com/dev/photos.getById
 func (vk *VK) PhotosGetByID(params Params) (response PhotosGetByIDResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("photos.getById", params, &response)
+	err = vk.RequestUnmarshal("photos.getById", &response, params, Params{"extended": false})
 
 	return
 }
@@ -238,8 +233,7 @@ type PhotosGetByIDExtendedResponse []object.PhotosPhotoFull
 //
 // https://vk.com/dev/photos.getById
 func (vk *VK) PhotosGetByIDExtended(params Params) (response PhotosGetByIDExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("photos.getById", params, &response)
+	err = vk.RequestUnmarshal("photos.getById", &response, params, Params{"extended": true})
 
 	return
 }
@@ -253,7 +247,7 @@ type PhotosGetChatUploadServerResponse struct {
 //
 // https://vk.com/dev/photos.getChatUploadServer
 func (vk *VK) PhotosGetChatUploadServer(params Params) (response PhotosGetChatUploadServerResponse, err error) {
-	err = vk.RequestUnmarshal("photos.getChatUploadServer", params, &response)
+	err = vk.RequestUnmarshal("photos.getChatUploadServer", &response, params)
 	return
 }
 
@@ -270,8 +264,7 @@ type PhotosGetCommentsResponse struct {
 //
 // https://vk.com/dev/photos.getComments
 func (vk *VK) PhotosGetComments(params Params) (response PhotosGetCommentsResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("photos.getComments", params, &response)
+	err = vk.RequestUnmarshal("photos.getComments", &response, params, Params{"extended": false})
 
 	return
 }
@@ -291,8 +284,7 @@ type PhotosGetCommentsExtendedResponse struct {
 //
 // https://vk.com/dev/photos.getComments
 func (vk *VK) PhotosGetCommentsExtended(params Params) (response PhotosGetCommentsExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("photos.getComments", params, &response)
+	err = vk.RequestUnmarshal("photos.getComments", &response, params, Params{"extended": true})
 
 	return
 }
@@ -309,7 +301,7 @@ func (vk *VK) PhotosGetMarketAlbumUploadServer(params Params) (
 	response PhotosGetMarketAlbumUploadServerResponse,
 	err error,
 ) {
-	err = vk.RequestUnmarshal("photos.getMarketAlbumUploadServer", params, &response)
+	err = vk.RequestUnmarshal("photos.getMarketAlbumUploadServer", &response, params)
 	return
 }
 
@@ -322,7 +314,7 @@ type PhotosGetMarketUploadServerResponse struct {
 //
 // https://vk.com/dev/photos.getMarketUploadServer
 func (vk *VK) PhotosGetMarketUploadServer(params Params) (response PhotosGetMarketUploadServerResponse, err error) {
-	err = vk.RequestUnmarshal("photos.getMarketUploadServer", params, &response)
+	err = vk.RequestUnmarshal("photos.getMarketUploadServer", &response, params)
 	return
 }
 
@@ -338,7 +330,7 @@ type PhotosGetMessagesUploadServerResponse struct {
 //
 // https://vk.com/dev/photos.getMessagesUploadServer
 func (vk *VK) PhotosGetMessagesUploadServer(params Params) (response PhotosGetMessagesUploadServerResponse, err error) {
-	err = vk.RequestUnmarshal("photos.getMessagesUploadServer", params, &response)
+	err = vk.RequestUnmarshal("photos.getMessagesUploadServer", &response, params)
 	return
 }
 
@@ -352,7 +344,7 @@ type PhotosGetNewTagsResponse struct {
 //
 // https://vk.com/dev/photos.getNewTags
 func (vk *VK) PhotosGetNewTags(params Params) (response PhotosGetNewTagsResponse, err error) {
-	err = vk.RequestUnmarshal("photos.getNewTags", params, &response)
+	err = vk.RequestUnmarshal("photos.getNewTags", &response, params)
 	return
 }
 
@@ -368,7 +360,7 @@ func (vk *VK) PhotosGetOwnerCoverPhotoUploadServer(params Params) (
 	response PhotosGetOwnerCoverPhotoUploadServerResponse,
 	err error,
 ) {
-	err = vk.RequestUnmarshal("photos.getOwnerCoverPhotoUploadServer", params, &response)
+	err = vk.RequestUnmarshal("photos.getOwnerCoverPhotoUploadServer", &response, params)
 	return
 }
 
@@ -385,7 +377,7 @@ func (vk *VK) PhotosGetOwnerPhotoUploadServer(params Params) (
 	response PhotosGetOwnerPhotoUploadServerResponse,
 	err error,
 ) {
-	err = vk.RequestUnmarshal("photos.getOwnerPhotoUploadServer", params, &response)
+	err = vk.RequestUnmarshal("photos.getOwnerPhotoUploadServer", &response, params)
 	return
 }
 
@@ -396,7 +388,7 @@ type PhotosGetTagsResponse []object.PhotosPhotoTag
 //
 // https://vk.com/dev/photos.getTags
 func (vk *VK) PhotosGetTags(params Params) (response PhotosGetTagsResponse, err error) {
-	err = vk.RequestUnmarshal("photos.getTags", params, &response)
+	err = vk.RequestUnmarshal("photos.getTags", &response, params)
 	return
 }
 
@@ -407,7 +399,7 @@ type PhotosGetUploadServerResponse object.PhotosPhotoUpload
 //
 // https://vk.com/dev/photos.getUploadServer
 func (vk *VK) PhotosGetUploadServer(params Params) (response PhotosGetUploadServerResponse, err error) {
-	err = vk.RequestUnmarshal("photos.getUploadServer", params, &response)
+	err = vk.RequestUnmarshal("photos.getUploadServer", &response, params)
 	return
 }
 
@@ -423,8 +415,7 @@ type PhotosGetUserPhotosResponse struct {
 //
 // https://vk.com/dev/photos.getUserPhotos
 func (vk *VK) PhotosGetUserPhotos(params Params) (response PhotosGetUserPhotosResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("photos.getUserPhotos", params, &response)
+	err = vk.RequestUnmarshal("photos.getUserPhotos", &response, params, Params{"extended": false})
 
 	return
 }
@@ -441,8 +432,7 @@ type PhotosGetUserPhotosExtendedResponse struct {
 //
 // https://vk.com/dev/photos.getUserPhotos
 func (vk *VK) PhotosGetUserPhotosExtended(params Params) (response PhotosGetUserPhotosExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("photos.getUserPhotos", params, &response)
+	err = vk.RequestUnmarshal("photos.getUserPhotos", &response, params, Params{"extended": true})
 
 	return
 }
@@ -454,7 +444,7 @@ type PhotosGetWallUploadServerResponse object.PhotosPhotoUpload
 //
 // https://vk.com/dev/photos.getWallUploadServer
 func (vk *VK) PhotosGetWallUploadServer(params Params) (response PhotosGetWallUploadServerResponse, err error) {
-	err = vk.RequestUnmarshal("photos.getWallUploadServer", params, &response)
+	err = vk.RequestUnmarshal("photos.getWallUploadServer", &response, params)
 	return
 }
 
@@ -462,7 +452,7 @@ func (vk *VK) PhotosGetWallUploadServer(params Params) (response PhotosGetWallUp
 //
 // https://vk.com/dev/photos.makeCover
 func (vk *VK) PhotosMakeCover(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.makeCover", params, &response)
+	err = vk.RequestUnmarshal("photos.makeCover", &response, params)
 	return
 }
 
@@ -470,7 +460,7 @@ func (vk *VK) PhotosMakeCover(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.moveMoves
 func (vk *VK) PhotosMove(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.move", params, &response)
+	err = vk.RequestUnmarshal("photos.move", &response, params)
 	return
 }
 
@@ -478,7 +468,7 @@ func (vk *VK) PhotosMove(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.putTag
 func (vk *VK) PhotosPutTag(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.putTag", params, &response)
+	err = vk.RequestUnmarshal("photos.putTag", &response, params)
 	return
 }
 
@@ -486,7 +476,7 @@ func (vk *VK) PhotosPutTag(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.removeTag
 func (vk *VK) PhotosRemoveTag(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.removeTag", params, &response)
+	err = vk.RequestUnmarshal("photos.removeTag", &response, params)
 	return
 }
 
@@ -494,7 +484,7 @@ func (vk *VK) PhotosRemoveTag(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.reorderAlbums
 func (vk *VK) PhotosReorderAlbums(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.reorderAlbums", params, &response)
+	err = vk.RequestUnmarshal("photos.reorderAlbums", &response, params)
 	return
 }
 
@@ -502,7 +492,7 @@ func (vk *VK) PhotosReorderAlbums(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.reorderPhotos
 func (vk *VK) PhotosReorderPhotos(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.reorderPhotos", params, &response)
+	err = vk.RequestUnmarshal("photos.reorderPhotos", &response, params)
 	return
 }
 
@@ -510,7 +500,7 @@ func (vk *VK) PhotosReorderPhotos(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.report
 func (vk *VK) PhotosReport(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.report", params, &response)
+	err = vk.RequestUnmarshal("photos.report", &response, params)
 	return
 }
 
@@ -518,7 +508,7 @@ func (vk *VK) PhotosReport(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.reportComment
 func (vk *VK) PhotosReportComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.reportComment", params, &response)
+	err = vk.RequestUnmarshal("photos.reportComment", &response, params)
 	return
 }
 
@@ -526,7 +516,7 @@ func (vk *VK) PhotosReportComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.restore
 func (vk *VK) PhotosRestore(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.restore", params, &response)
+	err = vk.RequestUnmarshal("photos.restore", &response, params)
 	return
 }
 
@@ -534,7 +524,7 @@ func (vk *VK) PhotosRestore(params Params) (response int, err error) {
 //
 // https://vk.com/dev/photos.restoreComment
 func (vk *VK) PhotosRestoreComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.restoreComment", params, &response)
+	err = vk.RequestUnmarshal("photos.restoreComment", &response, params)
 	return
 }
 
@@ -545,7 +535,7 @@ type PhotosSaveResponse []object.PhotosPhoto
 //
 // https://vk.com/dev/photos.save
 func (vk *VK) PhotosSave(params Params) (response PhotosSaveResponse, err error) {
-	err = vk.RequestUnmarshal("photos.save", params, &response)
+	err = vk.RequestUnmarshal("photos.save", &response, params)
 	return
 }
 
@@ -556,7 +546,7 @@ type PhotosSaveMarketAlbumPhotoResponse []object.PhotosPhoto
 //
 // https://vk.com/dev/photos.saveMarketAlbumPhoto
 func (vk *VK) PhotosSaveMarketAlbumPhoto(params Params) (response PhotosSaveMarketAlbumPhotoResponse, err error) {
-	err = vk.RequestUnmarshal("photos.saveMarketAlbumPhoto", params, &response)
+	err = vk.RequestUnmarshal("photos.saveMarketAlbumPhoto", &response, params)
 	return
 }
 
@@ -567,7 +557,7 @@ type PhotosSaveMarketPhotoResponse []object.PhotosPhoto
 //
 // https://vk.com/dev/photos.saveMarketPhoto
 func (vk *VK) PhotosSaveMarketPhoto(params Params) (response PhotosSaveMarketPhotoResponse, err error) {
-	err = vk.RequestUnmarshal("photos.saveMarketPhoto", params, &response)
+	err = vk.RequestUnmarshal("photos.saveMarketPhoto", &response, params)
 	return
 }
 
@@ -578,7 +568,7 @@ type PhotosSaveMessagesPhotoResponse []object.PhotosPhoto
 //
 // https://vk.com/dev/photos.saveMessagesPhoto
 func (vk *VK) PhotosSaveMessagesPhoto(params Params) (response PhotosSaveMessagesPhotoResponse, err error) {
-	err = vk.RequestUnmarshal("photos.saveMessagesPhoto", params, &response)
+	err = vk.RequestUnmarshal("photos.saveMessagesPhoto", &response, params)
 	return
 }
 
@@ -591,7 +581,7 @@ type PhotosSaveOwnerCoverPhotoResponse struct {
 //
 // https://vk.com/dev/photos.saveOwnerCoverPhoto
 func (vk *VK) PhotosSaveOwnerCoverPhoto(params Params) (response PhotosSaveOwnerCoverPhotoResponse, err error) {
-	err = vk.RequestUnmarshal("photos.saveOwnerCoverPhoto", params, &response)
+	err = vk.RequestUnmarshal("photos.saveOwnerCoverPhoto", &response, params)
 	return
 }
 
@@ -609,7 +599,7 @@ type PhotosSaveOwnerPhotoResponse struct {
 //
 // https://vk.com/dev/photos.saveOwnerPhoto
 func (vk *VK) PhotosSaveOwnerPhoto(params Params) (response PhotosSaveOwnerPhotoResponse, err error) {
-	err = vk.RequestUnmarshal("photos.saveOwnerPhoto", params, &response)
+	err = vk.RequestUnmarshal("photos.saveOwnerPhoto", &response, params)
 	return
 }
 
@@ -620,7 +610,7 @@ type PhotosSaveWallPhotoResponse []object.PhotosPhoto
 //
 // https://vk.com/dev/photos.saveWallPhoto
 func (vk *VK) PhotosSaveWallPhoto(params Params) (response PhotosSaveWallPhotoResponse, err error) {
-	err = vk.RequestUnmarshal("photos.saveWallPhoto", params, &response)
+	err = vk.RequestUnmarshal("photos.saveWallPhoto", &response, params)
 	return
 }
 
@@ -634,7 +624,7 @@ type PhotosSearchResponse struct {
 //
 // https://vk.com/dev/photos.search
 func (vk *VK) PhotosSearch(params Params) (response PhotosSearchResponse, err error) {
-	err = vk.RequestUnmarshal("photos.search", params, &response)
+	err = vk.RequestUnmarshal("photos.search", &response, params)
 	return
 }
 
@@ -642,6 +632,6 @@ func (vk *VK) PhotosSearch(params Params) (response PhotosSearchResponse, err er
 //
 // https://vk.com/dev/photos.skipTags
 func (vk *VK) PhotosSkipTags(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("photos.skipTags", params, &response)
+	err = vk.RequestUnmarshal("photos.skipTags", &response, params)
 	return
 }

--- a/api/photos_test.go
+++ b/api/photos_test.go
@@ -27,7 +27,7 @@ func TestVK_PhotosConfirmTags(t *testing.T) {
 
 	needUserToken(t)
 
-	ok, err := vkUser.PhotosConfirmTags(api.Params{})
+	ok, err := vkUser.PhotosConfirmTags(nil)
 	noError(t, err)
 	assert.Equal(t, 0, ok)
 }
@@ -140,7 +140,7 @@ func TestVK_PhotosDeclineTags(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.PhotosDeclineTags(api.Params{})
+	_, err := vkUser.PhotosDeclineTags(nil)
 	noError(t, err)
 }
 
@@ -363,7 +363,7 @@ func TestVK_PhotosGetNewTags(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.PhotosGetNewTags(api.Params{})
+	_, err := vkUser.PhotosGetNewTags(nil)
 	noError(t, err)
 }
 
@@ -384,7 +384,7 @@ func TestVK_PhotosGetOwnerPhotoUploadServer(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.PhotosGetOwnerPhotoUploadServer(api.Params{})
+	_, err := vkUser.PhotosGetOwnerPhotoUploadServer(nil)
 	noError(t, err)
 }
 
@@ -480,6 +480,6 @@ func TestVK_PhotosSkipTags(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.PhotosSkipTags(api.Params{})
+	_, err := vkUser.PhotosSkipTags(nil)
 	noError(t, err)
 }

--- a/api/podcasts.go
+++ b/api/podcasts.go
@@ -15,8 +15,7 @@ type PodcastsGetCatalogResponse struct {
 //
 // https://vk.com/dev/podcasts.getCatalog
 func (vk *VK) PodcastsGetCatalog(params Params) (response PodcastsGetCatalogResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("podcasts.getCatalog", params, &response)
+	err = vk.RequestUnmarshal("podcasts.getCatalog", &response, params, Params{"extended": false})
 
 	return
 }
@@ -33,8 +32,7 @@ type PodcastsGetCatalogExtendedResponse struct {
 //
 // https://vk.com/dev/podcasts.getCatalog
 func (vk *VK) PodcastsGetCatalogExtended(params Params) (response PodcastsGetCatalogExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("podcasts.getCatalog", params, &response)
+	err = vk.RequestUnmarshal("podcasts.getCatalog", &response, params, Params{"extended": true})
 
 	return
 }
@@ -46,7 +44,7 @@ type PodcastsGetCategoriesResponse []object.PodcastsCategory
 //
 // https://vk.com/dev/podcasts.getCategories
 func (vk *VK) PodcastsGetCategories(params Params) (response PodcastsGetCategoriesResponse, err error) {
-	err = vk.RequestUnmarshal("podcasts.getCategories", params, &response)
+	err = vk.RequestUnmarshal("podcasts.getCategories", &response, params)
 	return
 }
 
@@ -60,7 +58,7 @@ type PodcastsGetEpisodesResponse struct {
 //
 // https://vk.com/dev/podcasts.getEpisodes
 func (vk *VK) PodcastsGetEpisodes(params Params) (response PodcastsGetEpisodesResponse, err error) {
-	err = vk.RequestUnmarshal("podcasts.getEpisodes", params, &response)
+	err = vk.RequestUnmarshal("podcasts.getEpisodes", &response, params)
 	return
 }
 
@@ -76,8 +74,7 @@ type PodcastsGetFeedResponse struct {
 //
 // https://vk.com/dev/podcasts.getFeed
 func (vk *VK) PodcastsGetFeed(params Params) (response PodcastsGetFeedResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("podcasts.getFeed", params, &response)
+	err = vk.RequestUnmarshal("podcasts.getFeed", &response, params, Params{"extended": false})
 
 	return
 }
@@ -95,8 +92,7 @@ type PodcastsGetFeedExtendedResponse struct {
 //
 // https://vk.com/dev/podcasts.getFeed
 func (vk *VK) PodcastsGetFeedExtended(params Params) (response PodcastsGetFeedExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("podcasts.getFeed", params, &response)
+	err = vk.RequestUnmarshal("podcasts.getFeed", &response, params, Params{"extended": true})
 
 	return
 }
@@ -124,8 +120,7 @@ type PodcastsGetStartPageResponse struct {
 //
 // https://vk.com/dev/podcasts.getStartPage
 func (vk *VK) PodcastsGetStartPage(params Params) (response PodcastsGetStartPageResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("podcasts.getStartPage", params, &response)
+	err = vk.RequestUnmarshal("podcasts.getStartPage", &response, params, Params{"extended": false})
 
 	return
 }
@@ -154,8 +149,7 @@ type PodcastsGetStartPageExtendedResponse struct {
 //
 // https://vk.com/dev/podcasts.getStartPage
 func (vk *VK) PodcastsGetStartPageExtended(params Params) (response PodcastsGetStartPageExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("podcasts.getStartPage", params, &response)
+	err = vk.RequestUnmarshal("podcasts.getStartPage", &response, params, Params{"extended": true})
 
 	return
 }
@@ -164,7 +158,7 @@ func (vk *VK) PodcastsGetStartPageExtended(params Params) (response PodcastsGetS
 //
 // https://vk.com/dev/podcasts.markAsListened
 func (vk *VK) PodcastsMarkAsListened(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("podcasts.markAsListened", params, &response)
+	err = vk.RequestUnmarshal("podcasts.markAsListened", &response, params)
 	return
 }
 
@@ -172,7 +166,7 @@ func (vk *VK) PodcastsMarkAsListened(params Params) (response int, err error) {
 //
 // https://vk.com/dev/podcasts.subscribe
 func (vk *VK) PodcastsSubscribe(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("podcasts.subscribe", params, &response)
+	err = vk.RequestUnmarshal("podcasts.subscribe", &response, params)
 	return
 }
 
@@ -180,6 +174,6 @@ func (vk *VK) PodcastsSubscribe(params Params) (response int, err error) {
 //
 // https://vk.com/dev/podcasts.unsubscribe
 func (vk *VK) PodcastsUnsubscribe(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("podcasts.unsubscribe", params, &response)
+	err = vk.RequestUnmarshal("podcasts.unsubscribe", &response, params)
 	return
 }

--- a/api/podcasts_test.go
+++ b/api/podcasts_test.go
@@ -13,13 +13,13 @@ func TestVK_PodcastsGet(t *testing.T) {
 	t.Skip("7 Permission to perform this action is denied")
 	needUserToken(t)
 
-	_, err := vkUser.PodcastsGetCatalog(api.Params{})
+	_, err := vkUser.PodcastsGetCatalog(nil)
 	noError(t, err)
 
-	_, err = vkUser.PodcastsGetCatalogExtended(api.Params{})
+	_, err = vkUser.PodcastsGetCatalogExtended(nil)
 	noError(t, err)
 
-	_, err = vkUser.PodcastsGetCategories(api.Params{})
+	_, err = vkUser.PodcastsGetCategories(nil)
 	noError(t, err)
 
 	_, err = vkUser.PodcastsGetEpisodes(api.Params{
@@ -27,16 +27,16 @@ func TestVK_PodcastsGet(t *testing.T) {
 	})
 	noError(t, err)
 
-	_, err = vkUser.PodcastsGetFeed(api.Params{})
+	_, err = vkUser.PodcastsGetFeed(nil)
 	noError(t, err)
 
-	_, err = vkUser.PodcastsGetFeedExtended(api.Params{})
+	_, err = vkUser.PodcastsGetFeedExtended(nil)
 	noError(t, err)
 
-	_, err = vkUser.PodcastsGetStartPage(api.Params{})
+	_, err = vkUser.PodcastsGetStartPage(nil)
 	noError(t, err)
 
-	_, err = vkUser.PodcastsGetStartPageExtended(api.Params{})
+	_, err = vkUser.PodcastsGetStartPageExtended(nil)
 	noError(t, err)
 }
 

--- a/api/polls.go
+++ b/api/polls.go
@@ -6,7 +6,7 @@ import "github.com/SevereCloud/vksdk/object"
 //
 // https://vk.com/dev/polls.addVote
 func (vk *VK) PollsAddVote(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("polls.addVote", params, &response)
+	err = vk.RequestUnmarshal("polls.addVote", &response, params)
 	return
 }
 
@@ -17,7 +17,7 @@ type PollsCreateResponse object.PollsPoll
 //
 // https://vk.com/dev/polls.create
 func (vk *VK) PollsCreate(params Params) (response PollsCreateResponse, err error) {
-	err = vk.RequestUnmarshal("polls.create", params, &response)
+	err = vk.RequestUnmarshal("polls.create", &response, params)
 	return
 }
 
@@ -25,7 +25,7 @@ func (vk *VK) PollsCreate(params Params) (response PollsCreateResponse, err erro
 //
 // https://vk.com/dev/polls.deleteVote
 func (vk *VK) PollsDeleteVote(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("polls.deleteVote", params, &response)
+	err = vk.RequestUnmarshal("polls.deleteVote", &response, params)
 	return
 }
 
@@ -33,7 +33,7 @@ func (vk *VK) PollsDeleteVote(params Params) (response int, err error) {
 //
 // https://vk.com/dev/polls.edit
 func (vk *VK) PollsEdit(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("polls.edit", params, &response)
+	err = vk.RequestUnmarshal("polls.edit", &response, params)
 	return
 }
 
@@ -44,7 +44,7 @@ type PollsGetBackgroundsResponse []object.PollsBackground
 //
 // https://vk.com/dev/polls.getBackgrounds
 func (vk *VK) PollsGetBackgrounds(params Params) (response PollsGetBackgroundsResponse, err error) {
-	err = vk.RequestUnmarshal("polls.getBackgrounds", params, &response)
+	err = vk.RequestUnmarshal("polls.getBackgrounds", &response, params)
 	return
 }
 
@@ -55,7 +55,7 @@ type PollsGetByIDResponse object.PollsPoll
 //
 // https://vk.com/dev/polls.getById
 func (vk *VK) PollsGetByID(params Params) (response PollsGetByIDResponse, err error) {
-	err = vk.RequestUnmarshal("polls.getById", params, &response)
+	err = vk.RequestUnmarshal("polls.getById", &response, params)
 	return
 }
 
@@ -68,7 +68,7 @@ type PollsGetPhotoUploadServerResponse struct {
 //
 // https://vk.com/dev/polls.getPhotoUploadServer
 func (vk *VK) PollsGetPhotoUploadServer(params Params) (response PollsGetPhotoUploadServerResponse, err error) {
-	err = vk.RequestUnmarshal("polls.getPhotoUploadServer", params, &response)
+	err = vk.RequestUnmarshal("polls.getPhotoUploadServer", &response, params)
 	return
 }
 
@@ -79,7 +79,7 @@ type PollsGetVotersResponse []object.PollsVoters
 //
 // https://vk.com/dev/polls.getVoters
 func (vk *VK) PollsGetVoters(params Params) (response PollsGetVotersResponse, err error) {
-	err = vk.RequestUnmarshal("polls.getVoters", params, &response)
+	err = vk.RequestUnmarshal("polls.getVoters", &response, params)
 	return
 }
 
@@ -90,7 +90,7 @@ type PollsGetVotersFieldsResponse []object.PollsVotersFields
 //
 // https://vk.com/dev/polls.getVoters
 func (vk *VK) PollsGetVotersFields(params Params) (response PollsGetVotersFieldsResponse, err error) {
-	err = vk.RequestUnmarshal("polls.getVoters", params, &response)
+	err = vk.RequestUnmarshal("polls.getVoters", &response, params)
 	return
 }
 
@@ -101,6 +101,6 @@ type PollsSavePhotoResponse object.PollsPhoto
 //
 // https://vk.com/dev/polls.savePhoto
 func (vk *VK) PollsSavePhoto(params Params) (response PollsSavePhotoResponse, err error) {
-	err = vk.RequestUnmarshal("polls.savePhoto", params, &response)
+	err = vk.RequestUnmarshal("polls.savePhoto", &response, params)
 	return
 }

--- a/api/polls_test.go
+++ b/api/polls_test.go
@@ -47,7 +47,7 @@ func TestVK_PollsGetBackgrounds(t *testing.T) {
 
 	needUserToken(t)
 
-	res, err := vkUser.PollsGetBackgrounds(api.Params{})
+	res, err := vkUser.PollsGetBackgrounds(nil)
 	noError(t, err)
 
 	if assert.NotEmpty(t, res) {
@@ -92,7 +92,7 @@ func TestVK_PollsGetPhotoUploadServer(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.PollsGetPhotoUploadServer(api.Params{})
+	_, err := vkUser.PollsGetPhotoUploadServer(nil)
 	noError(t, err)
 }
 

--- a/api/prettycards.go
+++ b/api/prettycards.go
@@ -12,7 +12,7 @@ type PrettyCardsCreateResponse struct {
 //
 // https://vk.com/dev/prettyCards.create
 func (vk *VK) PrettyCardsCreate(params Params) (response PrettyCardsCreateResponse, err error) {
-	err = vk.RequestUnmarshal("prettyCards.create", params, &response)
+	err = vk.RequestUnmarshal("prettyCards.create", &response, params)
 	return
 }
 
@@ -27,7 +27,7 @@ type PrettyCardsDeleteResponse struct {
 //
 // https://vk.com/dev/prettyCards.delete
 func (vk *VK) PrettyCardsDelete(params Params) (response PrettyCardsDeleteResponse, err error) {
-	err = vk.RequestUnmarshal("prettyCards.delete", params, &response)
+	err = vk.RequestUnmarshal("prettyCards.delete", &response, params)
 	return
 }
 
@@ -41,7 +41,7 @@ type PrettyCardsEditResponse struct {
 //
 // https://vk.com/dev/prettyCards.edit
 func (vk *VK) PrettyCardsEdit(params Params) (response PrettyCardsEditResponse, err error) {
-	err = vk.RequestUnmarshal("prettyCards.edit", params, &response)
+	err = vk.RequestUnmarshal("prettyCards.edit", &response, params)
 	return
 }
 
@@ -55,7 +55,7 @@ type PrettyCardsGetResponse struct {
 //
 // https://vk.com/dev/prettyCards.get
 func (vk *VK) PrettyCardsGet(params Params) (response PrettyCardsGetResponse, err error) {
-	err = vk.RequestUnmarshal("prettyCards.get", params, &response)
+	err = vk.RequestUnmarshal("prettyCards.get", &response, params)
 	return
 }
 
@@ -66,7 +66,7 @@ type PrettyCardsGetByIDResponse []object.PrettyCardsPrettyCard
 //
 // https://vk.com/dev/prettyCards.getById
 func (vk *VK) PrettyCardsGetByID(params Params) (response PrettyCardsGetByIDResponse, err error) {
-	err = vk.RequestUnmarshal("prettyCards.getById", params, &response)
+	err = vk.RequestUnmarshal("prettyCards.getById", &response, params)
 	return
 }
 
@@ -74,6 +74,6 @@ func (vk *VK) PrettyCardsGetByID(params Params) (response PrettyCardsGetByIDResp
 //
 // https://vk.com/dev/prettyCards.getUploadURL
 func (vk *VK) PrettyCardsGetUploadURL(params Params) (response string, err error) {
-	err = vk.RequestUnmarshal("prettyCards.getUploadURL", params, &response)
+	err = vk.RequestUnmarshal("prettyCards.getUploadURL", &response, params)
 	return
 }

--- a/api/search.go
+++ b/api/search.go
@@ -12,6 +12,6 @@ type SearchGetHintsResponse struct {
 //
 // https://vk.com/dev/search.getHints
 func (vk *VK) SearchGetHints(params Params) (response SearchGetHintsResponse, err error) {
-	err = vk.RequestUnmarshal("search.getHints", params, &response)
+	err = vk.RequestUnmarshal("search.getHints", &response, params)
 	return
 }

--- a/api/secure.go
+++ b/api/secure.go
@@ -11,7 +11,7 @@ type SecureAddAppEventResponse int // FIXME: not found documentation. https://gi
 //
 // https://vk.com/dev/secure.addAppEvent
 func (vk *VK) SecureAddAppEvent(params Params) (response SecureAddAppEventResponse, err error) {
-	err = vk.RequestUnmarshal("secure.addAppEvent", params, &response)
+	err = vk.RequestUnmarshal("secure.addAppEvent", &response, params)
 	return
 }
 
@@ -22,7 +22,7 @@ type SecureCheckTokenResponse object.SecureTokenChecked
 //
 // https://vk.com/dev/secure.checkToken
 func (vk *VK) SecureCheckToken(params Params) (response SecureCheckTokenResponse, err error) {
-	err = vk.RequestUnmarshal("secure.checkToken", params, &response)
+	err = vk.RequestUnmarshal("secure.checkToken", &response, params)
 	return
 }
 
@@ -30,7 +30,7 @@ func (vk *VK) SecureCheckToken(params Params) (response SecureCheckTokenResponse
 //
 // https://vk.com/dev/secure.getAppBalance
 func (vk *VK) SecureGetAppBalance(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("secure.getAppBalance", params, &response)
+	err = vk.RequestUnmarshal("secure.getAppBalance", &response, params)
 	return
 }
 
@@ -42,7 +42,7 @@ type SecureGetSMSHistoryResponse []object.SecureSmsNotification
 //
 // https://vk.com/dev/secure.getSMSHistory
 func (vk *VK) SecureGetSMSHistory(params Params) (response SecureGetSMSHistoryResponse, err error) {
-	err = vk.RequestUnmarshal("secure.getSMSHistory", params, &response)
+	err = vk.RequestUnmarshal("secure.getSMSHistory", &response, params)
 	return
 }
 
@@ -53,7 +53,7 @@ type SecureGetTransactionsHistoryResponse []object.SecureTransaction
 //
 // https://vk.com/dev/secure.getTransactionsHistory
 func (vk *VK) SecureGetTransactionsHistory(params Params) (response SecureGetTransactionsHistoryResponse, err error) {
-	err = vk.RequestUnmarshal("secure.getTransactionsHistory", params, &response)
+	err = vk.RequestUnmarshal("secure.getTransactionsHistory", &response, params)
 	return
 }
 
@@ -64,7 +64,7 @@ type SecureGetUserLevelResponse []object.SecureLevel
 //
 // https://vk.com/dev/secure.getUserLevel
 func (vk *VK) SecureGetUserLevel(params Params) (response SecureGetUserLevelResponse, err error) {
-	err = vk.RequestUnmarshal("secure.getUserLevel", params, &response)
+	err = vk.RequestUnmarshal("secure.getUserLevel", &response, params)
 	return
 }
 
@@ -78,7 +78,7 @@ type SecureGiveEventStickerResponse []struct {
 //
 // https://vk.com/dev/secure.giveEventSticker
 func (vk *VK) SecureGiveEventSticker(params Params) (response SecureGiveEventStickerResponse, err error) {
-	err = vk.RequestUnmarshal("secure.giveEventSticker", params, &response)
+	err = vk.RequestUnmarshal("secure.giveEventSticker", &response, params)
 	return
 }
 
@@ -89,7 +89,7 @@ type SecureSendNotificationResponse []int // User ID
 //
 // https://vk.com/dev/secure.sendNotification
 func (vk *VK) SecureSendNotification(params Params) (response SecureSendNotificationResponse, err error) {
-	err = vk.RequestUnmarshal("secure.sendNotification", params, &response)
+	err = vk.RequestUnmarshal("secure.sendNotification", &response, params)
 	return
 }
 
@@ -97,7 +97,7 @@ func (vk *VK) SecureSendNotification(params Params) (response SecureSendNotifica
 //
 // https://vk.com/dev/secure.sendSMSNotification
 func (vk *VK) SecureSendSMSNotification(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("secure.sendSMSNotification", params, &response)
+	err = vk.RequestUnmarshal("secure.sendSMSNotification", &response, params)
 	return
 }
 
@@ -105,6 +105,6 @@ func (vk *VK) SecureSendSMSNotification(params Params) (response int, err error)
 //
 // https://vk.com/dev/secure.setCounter
 func (vk *VK) SecureSetCounter(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("secure.setCounter", params, &response)
+	err = vk.RequestUnmarshal("secure.setCounter", &response, params)
 	return
 }

--- a/api/stats.go
+++ b/api/stats.go
@@ -11,7 +11,7 @@ type StatsGetResponse []object.StatsPeriod
 //
 // https://vk.com/dev/stats.get
 func (vk *VK) StatsGet(params Params) (response StatsGetResponse, err error) {
-	err = vk.RequestUnmarshal("stats.get", params, &response)
+	err = vk.RequestUnmarshal("stats.get", &response, params)
 	return
 }
 
@@ -22,7 +22,7 @@ type StatsGetPostReachResponse []object.StatsWallpostStat
 //
 // https://vk.com/dev/stats.getPostReach
 func (vk *VK) StatsGetPostReach(params Params) (response StatsGetPostReachResponse, err error) {
-	err = vk.RequestUnmarshal("stats.getPostReach", params, &response)
+	err = vk.RequestUnmarshal("stats.getPostReach", &response, params)
 	return
 }
 
@@ -30,6 +30,6 @@ func (vk *VK) StatsGetPostReach(params Params) (response StatsGetPostReachRespon
 //
 // https://vk.com/dev/stats.trackVisitor
 func (vk *VK) StatsTrackVisitor(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("stats.trackVisitor", params, &response)
+	err = vk.RequestUnmarshal("stats.trackVisitor", &response, params)
 	return
 }

--- a/api/stats_test.go
+++ b/api/stats_test.go
@@ -26,6 +26,6 @@ func TestVK_StatsTrackVisitor(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.StatsTrackVisitor(api.Params{})
+	_, err := vkUser.StatsTrackVisitor(nil)
 	noError(t, err)
 }

--- a/api/status.go
+++ b/api/status.go
@@ -12,12 +12,12 @@ type StatusGetResponse struct {
 
 // StatusGet returns data required to show the status of a user or community.
 func (vk *VK) StatusGet(params Params) (response StatusGetResponse, err error) {
-	err = vk.RequestUnmarshal("status.get", params, &response)
+	err = vk.RequestUnmarshal("status.get", &response, params)
 	return
 }
 
 // StatusSet sets a new status for the current user.
 func (vk *VK) StatusSet(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("status.set", params, &response)
+	err = vk.RequestUnmarshal("status.set", &response, params)
 	return
 }

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -11,7 +11,7 @@ func TestVK_StatusGet(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.StatusGet(api.Params{})
+	_, err := vkUser.StatusGet(nil)
 	noError(t, err)
 }
 

--- a/api/storage.go
+++ b/api/storage.go
@@ -23,7 +23,7 @@ func (s StorageGetResponse) ToMap() map[string]string {
 //
 // https://vk.com/dev/storage.get
 func (vk *VK) StorageGet(params Params) (response StorageGetResponse, err error) {
-	err = vk.RequestUnmarshal("storage.get", params, &response)
+	err = vk.RequestUnmarshal("storage.get", &response, params)
 
 	return
 }
@@ -35,7 +35,7 @@ type StorageGetKeysResponse []string
 //
 // https://vk.com/dev/storage.getKeys
 func (vk *VK) StorageGetKeys(params Params) (response StorageGetKeysResponse, err error) {
-	err = vk.RequestUnmarshal("storage.getKeys", params, &response)
+	err = vk.RequestUnmarshal("storage.getKeys", &response, params)
 	return
 }
 
@@ -43,6 +43,6 @@ func (vk *VK) StorageGetKeys(params Params) (response StorageGetKeysResponse, er
 //
 // https://vk.com/dev/storage.set
 func (vk *VK) StorageSet(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("storage.set", params, &response)
+	err = vk.RequestUnmarshal("storage.set", &response, params)
 	return
 }

--- a/api/storage_test.go
+++ b/api/storage_test.go
@@ -24,7 +24,7 @@ func TestVK_StorageGetKeys(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.StorageGetKeys(api.Params{})
+	_, err := vkUser.StorageGetKeys(nil)
 	noError(t, err)
 }
 

--- a/api/stories.go
+++ b/api/stories.go
@@ -6,7 +6,7 @@ import "github.com/SevereCloud/vksdk/object"
 //
 // https://vk.com/dev/stories.banOwner
 func (vk *VK) StoriesBanOwner(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("stories.banOwner", params, &response)
+	err = vk.RequestUnmarshal("stories.banOwner", &response, params)
 	return
 }
 
@@ -14,7 +14,7 @@ func (vk *VK) StoriesBanOwner(params Params) (response int, err error) {
 //
 // https://vk.com/dev/stories.delete
 func (vk *VK) StoriesDelete(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("stories.delete", params, &response)
+	err = vk.RequestUnmarshal("stories.delete", &response, params)
 	return
 }
 
@@ -32,8 +32,7 @@ type StoriesGetResponse struct {
 //
 // https://vk.com/dev/stories.get
 func (vk *VK) StoriesGet(params Params) (response StoriesGetResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("stories.get", params, &response)
+	err = vk.RequestUnmarshal("stories.get", &response, params, Params{"extended": false})
 
 	return
 }
@@ -53,8 +52,7 @@ type StoriesGetExtendedResponse struct {
 //
 // https://vk.com/dev/stories.get
 func (vk *VK) StoriesGetExtended(params Params) (response StoriesGetExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("stories.get", params, &response)
+	err = vk.RequestUnmarshal("stories.get", &response, params, Params{"extended": true})
 
 	return
 }
@@ -71,8 +69,7 @@ type StoriesGetBannedResponse struct {
 //
 // https://vk.com/dev/stories.getBanned
 func (vk *VK) StoriesGetBanned(params Params) (response StoriesGetBannedResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("stories.getBanned", params, &response)
+	err = vk.RequestUnmarshal("stories.getBanned", &response, params, Params{"extended": false})
 
 	return
 }
@@ -90,8 +87,7 @@ type StoriesGetBannedExtendedResponse struct {
 //
 // https://vk.com/dev/stories.getBanned
 func (vk *VK) StoriesGetBannedExtended(params Params) (response StoriesGetBannedExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("stories.getBanned", params, &response)
+	err = vk.RequestUnmarshal("stories.getBanned", &response, params, Params{"extended": true})
 
 	return
 }
@@ -108,8 +104,7 @@ type StoriesGetByIDResponse struct {
 //
 // https://vk.com/dev/stories.getById
 func (vk *VK) StoriesGetByID(params Params) (response StoriesGetByIDResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("stories.getById", params, &response)
+	err = vk.RequestUnmarshal("stories.getById", &response, params, Params{"extended": false})
 
 	return
 }
@@ -127,8 +122,7 @@ type StoriesGetByIDExtendedResponse struct {
 //
 // https://vk.com/dev/stories.getById
 func (vk *VK) StoriesGetByIDExtended(params Params) (response StoriesGetByIDExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("stories.getById", params, &response)
+	err = vk.RequestUnmarshal("stories.getById", &response, params, Params{"extended": true})
 
 	return
 }
@@ -144,7 +138,7 @@ type StoriesGetPhotoUploadServerResponse struct {
 //
 // https://vk.com/dev/stories.getPhotoUploadServer
 func (vk *VK) StoriesGetPhotoUploadServer(params Params) (response StoriesGetPhotoUploadServerResponse, err error) {
-	err = vk.RequestUnmarshal("stories.getPhotoUploadServer", params, &response)
+	err = vk.RequestUnmarshal("stories.getPhotoUploadServer", &response, params)
 	return
 }
 
@@ -160,8 +154,7 @@ type StoriesGetRepliesResponse struct {
 //
 // https://vk.com/dev/stories.getReplies
 func (vk *VK) StoriesGetReplies(params Params) (response StoriesGetRepliesResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("stories.getReplies", params, &response)
+	err = vk.RequestUnmarshal("stories.getReplies", &response, params, Params{"extended": false})
 
 	return
 }
@@ -179,8 +172,7 @@ type StoriesGetRepliesExtendedResponse struct {
 //
 // https://vk.com/dev/stories.getReplies
 func (vk *VK) StoriesGetRepliesExtended(params Params) (response StoriesGetRepliesExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("stories.getReplies", params, &response)
+	err = vk.RequestUnmarshal("stories.getReplies", &response, params, Params{"extended": true})
 
 	return
 }
@@ -192,7 +184,7 @@ type StoriesGetStatsResponse object.StoriesStoryStats
 //
 // https://vk.com/dev/stories.getStats
 func (vk *VK) StoriesGetStats(params Params) (response StoriesGetStatsResponse, err error) {
-	err = vk.RequestUnmarshal("stories.getStats", params, &response)
+	err = vk.RequestUnmarshal("stories.getStats", &response, params)
 	return
 }
 
@@ -207,7 +199,7 @@ type StoriesGetVideoUploadServerResponse struct {
 //
 // https://vk.com/dev/stories.getVideoUploadServer
 func (vk *VK) StoriesGetVideoUploadServer(params Params) (response StoriesGetVideoUploadServerResponse, err error) {
-	err = vk.RequestUnmarshal("stories.getVideoUploadServer", params, &response)
+	err = vk.RequestUnmarshal("stories.getVideoUploadServer", &response, params)
 	return
 }
 
@@ -223,7 +215,7 @@ type StoriesGetViewersResponse struct {
 //
 // https://vk.com/dev/stories.getViewers
 func (vk *VK) StoriesGetViewers(params Params) (response StoriesGetViewersResponse, err error) {
-	err = vk.RequestUnmarshal("stories.getViewers", params, &response)
+	err = vk.RequestUnmarshal("stories.getViewers", &response, params)
 
 	return
 }
@@ -232,7 +224,7 @@ func (vk *VK) StoriesGetViewers(params Params) (response StoriesGetViewersRespon
 //
 // https://vk.com/dev/stories.hideAllReplies
 func (vk *VK) StoriesHideAllReplies(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("stories.hideAllReplies", params, &response)
+	err = vk.RequestUnmarshal("stories.hideAllReplies", &response, params)
 	return
 }
 
@@ -240,7 +232,7 @@ func (vk *VK) StoriesHideAllReplies(params Params) (response int, err error) {
 //
 // https://vk.com/dev/stories.hideReply
 func (vk *VK) StoriesHideReply(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("stories.hideReply", params, &response)
+	err = vk.RequestUnmarshal("stories.hideReply", &response, params)
 	return
 }
 
@@ -254,7 +246,7 @@ type StoriesSaveResponse struct {
 //
 // https://vk.com/dev/stories.save
 func (vk *VK) StoriesSave(params Params) (response StoriesSaveResponse, err error) {
-	err = vk.RequestUnmarshal("stories.save", params, &response)
+	err = vk.RequestUnmarshal("stories.save", &response, params)
 	return
 }
 
@@ -270,8 +262,7 @@ type StoriesSearchResponse struct {
 //
 // https://vk.com/dev/stories.search
 func (vk *VK) StoriesSearch(params Params) (response StoriesSearchResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("stories.search", params, &response)
+	err = vk.RequestUnmarshal("stories.search", &response, params, Params{"extended": false})
 
 	return
 }
@@ -289,8 +280,7 @@ type StoriesSearchExtendedResponse struct {
 //
 // https://vk.com/dev/stories.search
 func (vk *VK) StoriesSearchExtended(params Params) (response StoriesSearchExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("stories.search", params, &response)
+	err = vk.RequestUnmarshal("stories.search", &response, params, Params{"extended": true})
 
 	return
 }
@@ -302,7 +292,7 @@ func (vk *VK) StoriesSearchExtended(params Params) (response StoriesSearchExtend
 //
 // https://vk.com/dev/stories.sendInteraction
 func (vk *VK) StoriesSendInteraction(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("stories.sendInteraction", params, &response)
+	err = vk.RequestUnmarshal("stories.sendInteraction", &response, params)
 	return
 }
 
@@ -310,6 +300,6 @@ func (vk *VK) StoriesSendInteraction(params Params) (response int, err error) {
 //
 // https://vk.com/dev/stories.unbanOwner
 func (vk *VK) StoriesUnbanOwner(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("stories.unbanOwner", params, &response)
+	err = vk.RequestUnmarshal("stories.unbanOwner", &response, params)
 	return
 }

--- a/api/stories_test.go
+++ b/api/stories_test.go
@@ -18,12 +18,12 @@ func TestVK_StoriesBanOwner(t *testing.T) {
 	})
 	noError(t, err)
 
-	banned, err := vkUser.StoriesGetBanned(api.Params{})
+	banned, err := vkUser.StoriesGetBanned(nil)
 	noError(t, err)
 	assert.NotEmpty(t, banned.Count)
 	assert.NotEmpty(t, banned.Items)
 
-	bannedEx, err := vkUser.StoriesGetBannedExtended(api.Params{})
+	bannedEx, err := vkUser.StoriesGetBannedExtended(nil)
 	noError(t, err)
 	assert.NotEmpty(t, bannedEx.Count)
 	assert.NotEmpty(t, bannedEx.Items)
@@ -41,7 +41,7 @@ func TestVK_StoriesGet(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.StoriesGet(api.Params{})
+	_, err := vkUser.StoriesGet(nil)
 	noError(t, err)
 }
 
@@ -50,7 +50,7 @@ func TestVK_StoriesGetExtended(t *testing.T) {
 
 	needUserToken(t)
 
-	_, err := vkUser.StoriesGetExtended(api.Params{})
+	_, err := vkUser.StoriesGetExtended(nil)
 	noError(t, err)
 }
 

--- a/api/streaming.go
+++ b/api/streaming.go
@@ -10,7 +10,7 @@ type StreamingGetServerURLResponse struct {
 //
 // https://vk.com/dev/streaming.getServerUrl
 func (vk *VK) StreamingGetServerURL(params Params) (response StreamingGetServerURLResponse, err error) {
-	err = vk.RequestUnmarshal("streaming.getServerUrl", params, &response)
+	err = vk.RequestUnmarshal("streaming.getServerUrl", &response, params)
 	return
 }
 
@@ -23,7 +23,7 @@ type StreamingGetSettingsResponse struct {
 //
 // https://vk.com/dev/streaming.getSettings
 func (vk *VK) StreamingGetSettings(params Params) (response StreamingGetSettingsResponse, err error) {
-	err = vk.RequestUnmarshal("streaming.getSettings", params, &response)
+	err = vk.RequestUnmarshal("streaming.getSettings", &response, params)
 	return
 }
 
@@ -40,7 +40,7 @@ type StreamingGetStatsResponse []struct {
 //
 // https://vk.com/dev/streaming.getStats
 func (vk *VK) StreamingGetStats(params Params) (response StreamingGetStatsResponse, err error) {
-	err = vk.RequestUnmarshal("streaming.getStats", params, &response)
+	err = vk.RequestUnmarshal("streaming.getStats", &response, params)
 	return
 }
 
@@ -53,7 +53,7 @@ type StreamingGetStemResponse struct {
 //
 // https://vk.com/dev/streaming.getStem
 func (vk *VK) StreamingGetStem(params Params) (response StreamingGetStemResponse, err error) {
-	err = vk.RequestUnmarshal("streaming.getStem", params, &response)
+	err = vk.RequestUnmarshal("streaming.getStem", &response, params)
 	return
 }
 
@@ -61,7 +61,7 @@ func (vk *VK) StreamingGetStem(params Params) (response StreamingGetStemResponse
 //
 // https://vk.com/dev/streaming.setSettings
 func (vk *VK) StreamingSetSettings(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("streaming.setSettings", params, &response)
+	err = vk.RequestUnmarshal("streaming.setSettings", &response, params)
 
 	return
 }

--- a/api/streaming_test.go
+++ b/api/streaming_test.go
@@ -13,7 +13,7 @@ func TestVK_StreamingGetServerURL(t *testing.T) {
 	needServiceToken(t)
 
 	t.Run("StreamingGetServerURL not empty", func(t *testing.T) {
-		response, err := vkService.StreamingGetServerURL(api.Params{})
+		response, err := vkService.StreamingGetServerURL(nil)
 		if err != nil {
 			t.Errorf("%v", err)
 		}
@@ -33,7 +33,7 @@ func TestVK_StreamingGetSettings(t *testing.T) {
 	needServiceToken(t)
 
 	t.Run("StreamingGetSettings not empty", func(t *testing.T) {
-		response, err := vkService.StreamingGetSettings(api.Params{})
+		response, err := vkService.StreamingGetSettings(nil)
 		if err != nil {
 			t.Errorf("%v", err)
 		}
@@ -112,35 +112,35 @@ func TestVK_StreamingError(t *testing.T) {
 	vk := api.NewVK("")
 
 	t.Run("StreamingGetServerURL error", func(t *testing.T) {
-		_, err := vk.StreamingGetServerURL(api.Params{})
+		_, err := vk.StreamingGetServerURL(nil)
 		if !errors.Is(err, api.ErrAuth) {
 			t.Errorf("StreamingGetServerURL error bad %v", err)
 		}
 	})
 
 	t.Run("StreamingGetSettings error", func(t *testing.T) {
-		_, err := vk.StreamingGetSettings(api.Params{})
+		_, err := vk.StreamingGetSettings(nil)
 		if !errors.Is(err, api.ErrAuth) {
 			t.Errorf("StreamingGetSettings error bad %v", err)
 		}
 	})
 
 	t.Run("StreamingGetStats error", func(t *testing.T) {
-		_, err := vk.StreamingGetStats(api.Params{})
+		_, err := vk.StreamingGetStats(nil)
 		if !errors.Is(err, api.ErrAuth) {
 			t.Errorf("StreamingGetStats error bad %v", err)
 		}
 	})
 
 	t.Run("StreamingGetStem error", func(t *testing.T) {
-		_, err := vk.StreamingGetStem(api.Params{})
+		_, err := vk.StreamingGetStem(nil)
 		if !errors.Is(err, api.ErrAuth) {
 			t.Errorf("StreamingGetStem error bad %v", err)
 		}
 	})
 
 	t.Run("StreamingSetSettings error", func(t *testing.T) {
-		_, err := vk.StreamingSetSettings(api.Params{})
+		_, err := vk.StreamingSetSettings(nil)
 		if !errors.Is(err, api.ErrAuth) {
 			t.Errorf("StreamingSetSettings error bad %v", err)
 		}

--- a/api/upload.go
+++ b/api/upload.go
@@ -561,7 +561,7 @@ func (vk *VK) uploadDoc(url, title, tags string, file io.Reader) (response DocsS
 //
 // Limits: file size up to 200 MB.
 func (vk *VK) UploadDoc(title, tags string, file io.Reader) (response DocsSaveResponse, err error) {
-	uploadServer, err := vk.DocsGetUploadServer(Params{})
+	uploadServer, err := vk.DocsGetUploadServer(nil)
 	if err != nil {
 		return
 	}
@@ -595,7 +595,7 @@ func (vk *VK) UploadGroupDoc(groupID int, title, tags string, file io.Reader) (r
 //
 // Limits: file size up to 200 MB.
 func (vk *VK) UploadWallDoc(title, tags string, file io.Reader) (response DocsSaveResponse, err error) {
-	uploadServer, err := vk.DocsGetWallUploadServer(Params{})
+	uploadServer, err := vk.DocsGetWallUploadServer(nil)
 	if err != nil {
 		return
 	}
@@ -841,7 +841,7 @@ type uploadPrettyCardsPhotoHandler struct {
 //
 // Supported formats: JPG, PNG, GIF.
 func (vk *VK) UploadPrettyCardsPhoto(file io.Reader) (response string, err error) {
-	uploadURL, err := vk.PrettyCardsGetUploadURL(Params{})
+	uploadURL, err := vk.PrettyCardsGetUploadURL(nil)
 	if err != nil {
 		return
 	}
@@ -876,7 +876,7 @@ type uploadLeadFormsPhotoHandler struct {
 //
 // Supported formats: JPG, PNG, GIF.
 func (vk *VK) UploadLeadFormsPhoto(file io.Reader) (response string, err error) {
-	uploadURL, err := vk.LeadFormsGetUploadURL(Params{})
+	uploadURL, err := vk.LeadFormsGetUploadURL(nil)
 	if err != nil {
 		return
 	}

--- a/api/users.go
+++ b/api/users.go
@@ -11,7 +11,7 @@ type UsersGetResponse []object.UsersUser
 //
 // https://vk.com/dev/users.get
 func (vk *VK) UsersGet(params Params) (response UsersGetResponse, err error) {
-	err = vk.RequestUnmarshal("users.get", params, &response)
+	err = vk.RequestUnmarshal("users.get", &response, params)
 	return
 }
 
@@ -28,8 +28,7 @@ type UsersGetFollowersResponse struct {
 //
 // https://vk.com/dev/users.getFollowers
 func (vk *VK) UsersGetFollowers(params Params) (response UsersGetFollowersResponse, err error) {
-	params["fields"] = ""
-	err = vk.RequestUnmarshal("users.getFollowers", params, &response)
+	err = vk.RequestUnmarshal("users.getFollowers", &response, params, Params{"fields": ""})
 
 	return
 }
@@ -47,11 +46,12 @@ type UsersGetFollowersFieldsResponse struct {
 //
 // https://vk.com/dev/users.getFollowers
 func (vk *VK) UsersGetFollowersFields(params Params) (response UsersGetFollowersFieldsResponse, err error) {
+	reqParams := make(Params)
 	if v, prs := params["fields"]; v == "" || !prs {
-		params["fields"] = "id"
+		reqParams["fields"] = "id"
 	}
 
-	err = vk.RequestUnmarshal("users.getFollowers", params, &response)
+	err = vk.RequestUnmarshal("users.getFollowers", &response, params, reqParams)
 
 	return
 }
@@ -76,8 +76,7 @@ type UsersGetSubscriptionsResponse struct {
 //
 // BUG(SevereCloud): UsersGetSubscriptions bad response with extended=1.
 func (vk *VK) UsersGetSubscriptions(params Params) (response UsersGetSubscriptionsResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("users.getSubscriptions", params, &response)
+	err = vk.RequestUnmarshal("users.getSubscriptions", &response, params, Params{"extended": false})
 
 	return
 }
@@ -86,7 +85,7 @@ func (vk *VK) UsersGetSubscriptions(params Params) (response UsersGetSubscriptio
 //
 // https://vk.com/dev/users.report
 func (vk *VK) UsersReport(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("users.report", params, &response)
+	err = vk.RequestUnmarshal("users.report", &response, params)
 	return
 }
 
@@ -100,6 +99,6 @@ type UsersSearchResponse struct {
 //
 // https://vk.com/dev/users.search
 func (vk *VK) UsersSearch(params Params) (response UsersSearchResponse, err error) {
-	err = vk.RequestUnmarshal("users.search", params, &response)
+	err = vk.RequestUnmarshal("users.search", &response, params)
 	return
 }

--- a/api/utils.go
+++ b/api/utils.go
@@ -13,7 +13,7 @@ type UtilsCheckLinkResponse object.UtilsLinkChecked
 //
 // https://vk.com/dev/utils.checkLink
 func (vk *VK) UtilsCheckLink(params Params) (response UtilsCheckLinkResponse, err error) {
-	err = vk.RequestUnmarshal("utils.checkLink", params, &response)
+	err = vk.RequestUnmarshal("utils.checkLink", &response, params)
 	return
 }
 
@@ -21,7 +21,7 @@ func (vk *VK) UtilsCheckLink(params Params) (response UtilsCheckLinkResponse, er
 //
 // https://vk.com/dev/utils.deleteFromLastShortened
 func (vk *VK) UtilsDeleteFromLastShortened(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("utils.deleteFromLastShortened", params, &response)
+	err = vk.RequestUnmarshal("utils.deleteFromLastShortened", &response, params)
 	return
 }
 
@@ -35,7 +35,7 @@ type UtilsGetLastShortenedLinksResponse struct {
 //
 // https://vk.com/dev/utils.getLastShortenedLinks
 func (vk *VK) UtilsGetLastShortenedLinks(params Params) (response UtilsGetLastShortenedLinksResponse, err error) {
-	err = vk.RequestUnmarshal("utils.getLastShortenedLinks", params, &response)
+	err = vk.RequestUnmarshal("utils.getLastShortenedLinks", &response, params)
 	return
 }
 
@@ -48,8 +48,7 @@ type UtilsGetLinkStatsResponse object.UtilsLinkStats
 //
 // https://vk.com/dev/utils.getLinkStats
 func (vk *VK) UtilsGetLinkStats(params Params) (response UtilsGetLinkStatsResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("utils.getLinkStats", params, &response)
+	err = vk.RequestUnmarshal("utils.getLinkStats", &response, params, Params{"extended": false})
 
 	return
 }
@@ -63,8 +62,7 @@ type UtilsGetLinkStatsExtendedResponse object.UtilsLinkStatsExtended
 //
 // https://vk.com/dev/utils.getLinkStats
 func (vk *VK) UtilsGetLinkStatsExtended(params Params) (response UtilsGetLinkStatsExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("utils.getLinkStats", params, &response)
+	err = vk.RequestUnmarshal("utils.getLinkStats", &response, params, Params{"extended": true})
 
 	return
 }
@@ -73,7 +71,7 @@ func (vk *VK) UtilsGetLinkStatsExtended(params Params) (response UtilsGetLinkSta
 //
 // https://vk.com/dev/utils.getServerTime
 func (vk *VK) UtilsGetServerTime(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("utils.getServerTime", params, &response)
+	err = vk.RequestUnmarshal("utils.getServerTime", &response, params)
 	return
 }
 
@@ -84,7 +82,7 @@ type UtilsGetShortLinkResponse object.UtilsShortLink
 //
 // https://vk.com/dev/utils.getShortLink
 func (vk *VK) UtilsGetShortLink(params Params) (response UtilsGetShortLinkResponse, err error) {
-	err = vk.RequestUnmarshal("utils.getShortLink", params, &response)
+	err = vk.RequestUnmarshal("utils.getShortLink", &response, params)
 	return
 }
 

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -33,7 +33,7 @@ func TestVK_UtilsGetShortLink(t *testing.T) {
 	noError(t, err)
 	assert.NotEmpty(t, shortLink)
 
-	res, err := vkUser.UtilsGetLastShortenedLinks(api.Params{})
+	res, err := vkUser.UtilsGetLastShortenedLinks(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res.Count)
 	assert.NotEmpty(t, res.Items)
@@ -73,7 +73,7 @@ func TestVK_UtilsGetServerTime(t *testing.T) {
 
 	needGroupToken(t)
 
-	res, err := vkGroup.UtilsGetServerTime(api.Params{})
+	res, err := vkGroup.UtilsGetServerTime(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res)
 }

--- a/api/video.go
+++ b/api/video.go
@@ -8,7 +8,7 @@ import (
 //
 // https://vk.com/dev/video.add
 func (vk *VK) VideoAdd(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.add", params, &response)
+	err = vk.RequestUnmarshal("video.add", &response, params)
 	return
 }
 
@@ -21,7 +21,7 @@ type VideoAddAlbumResponse struct {
 //
 // https://vk.com/dev/video.addAlbum
 func (vk *VK) VideoAddAlbum(params Params) (response VideoAddAlbumResponse, err error) {
-	err = vk.RequestUnmarshal("video.addAlbum", params, &response)
+	err = vk.RequestUnmarshal("video.addAlbum", &response, params)
 	return
 }
 
@@ -29,7 +29,7 @@ func (vk *VK) VideoAddAlbum(params Params) (response VideoAddAlbumResponse, err 
 //
 // https://vk.com/dev/video.addToAlbum
 func (vk *VK) VideoAddToAlbum(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.addToAlbum", params, &response)
+	err = vk.RequestUnmarshal("video.addToAlbum", &response, params)
 	return
 }
 
@@ -37,7 +37,7 @@ func (vk *VK) VideoAddToAlbum(params Params) (response int, err error) {
 //
 // https://vk.com/dev/video.createComment
 func (vk *VK) VideoCreateComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.createComment", params, &response)
+	err = vk.RequestUnmarshal("video.createComment", &response, params)
 	return
 }
 
@@ -45,7 +45,7 @@ func (vk *VK) VideoCreateComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/video.delete
 func (vk *VK) VideoDelete(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.delete", params, &response)
+	err = vk.RequestUnmarshal("video.delete", &response, params)
 	return
 }
 
@@ -53,7 +53,7 @@ func (vk *VK) VideoDelete(params Params) (response int, err error) {
 //
 // https://vk.com/dev/video.deleteAlbum
 func (vk *VK) VideoDeleteAlbum(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.deleteAlbum", params, &response)
+	err = vk.RequestUnmarshal("video.deleteAlbum", &response, params)
 	return
 }
 
@@ -61,7 +61,7 @@ func (vk *VK) VideoDeleteAlbum(params Params) (response int, err error) {
 //
 // https://vk.com/dev/video.deleteComment
 func (vk *VK) VideoDeleteComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.deleteComment", params, &response)
+	err = vk.RequestUnmarshal("video.deleteComment", &response, params)
 	return
 }
 
@@ -69,7 +69,7 @@ func (vk *VK) VideoDeleteComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/video.edit
 func (vk *VK) VideoEdit(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.edit", params, &response)
+	err = vk.RequestUnmarshal("video.edit", &response, params)
 	return
 }
 
@@ -77,7 +77,7 @@ func (vk *VK) VideoEdit(params Params) (response int, err error) {
 //
 // https://vk.com/dev/video.editAlbum
 func (vk *VK) VideoEditAlbum(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.editAlbum", params, &response)
+	err = vk.RequestUnmarshal("video.editAlbum", &response, params)
 	return
 }
 
@@ -85,7 +85,7 @@ func (vk *VK) VideoEditAlbum(params Params) (response int, err error) {
 //
 // https://vk.com/dev/video.editComment
 func (vk *VK) VideoEditComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.editComment", params, &response)
+	err = vk.RequestUnmarshal("video.editComment", &response, params)
 	return
 }
 
@@ -101,8 +101,7 @@ type VideoGetResponse struct {
 //
 // https://vk.com/dev/video.get
 func (vk *VK) VideoGet(params Params) (response VideoGetResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("video.get", params, &response)
+	err = vk.RequestUnmarshal("video.get", &response, params, Params{"extended": false})
 
 	return
 }
@@ -120,8 +119,7 @@ type VideoGetExtendedResponse struct {
 //
 // https://vk.com/dev/video.get
 func (vk *VK) VideoGetExtended(params Params) (response VideoGetExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("video.get", params, &response)
+	err = vk.RequestUnmarshal("video.get", &response, params, Params{"extended": true})
 
 	return
 }
@@ -133,7 +131,7 @@ type VideoGetAlbumByIDResponse object.VideoVideoAlbumFull
 //
 // https://vk.com/dev/video.getAlbumById
 func (vk *VK) VideoGetAlbumByID(params Params) (response VideoGetAlbumByIDResponse, err error) {
-	err = vk.RequestUnmarshal("video.getAlbumById", params, &response)
+	err = vk.RequestUnmarshal("video.getAlbumById", &response, params)
 	return
 }
 
@@ -149,8 +147,7 @@ type VideoGetAlbumsResponse struct {
 //
 // https://vk.com/dev/video.getAlbums
 func (vk *VK) VideoGetAlbums(params Params) (response VideoGetAlbumsResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("video.getAlbums", params, &response)
+	err = vk.RequestUnmarshal("video.getAlbums", &response, params, Params{"extended": false})
 
 	return
 }
@@ -167,8 +164,7 @@ type VideoGetAlbumsExtendedResponse struct {
 //
 // https://vk.com/dev/video.getAlbums
 func (vk *VK) VideoGetAlbumsExtended(params Params) (response VideoGetAlbumsExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("video.getAlbums", params, &response)
+	err = vk.RequestUnmarshal("video.getAlbums", &response, params, Params{"extended": true})
 
 	return
 }
@@ -182,8 +178,7 @@ type VideoGetAlbumsByVideoResponse []int
 //
 // https://vk.com/dev/video.getAlbumsByVideo
 func (vk *VK) VideoGetAlbumsByVideo(params Params) (response VideoGetAlbumsByVideoResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("video.getAlbumsByVideo", params, &response)
+	err = vk.RequestUnmarshal("video.getAlbumsByVideo", &response, params, Params{"extended": false})
 
 	return
 }
@@ -200,8 +195,7 @@ type VideoGetAlbumsByVideoExtendedResponse struct {
 //
 // https://vk.com/dev/video.getAlbumsByVideo
 func (vk *VK) VideoGetAlbumsByVideoExtended(params Params) (response VideoGetAlbumsByVideoExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("video.getAlbumsByVideo", params, &response)
+	err = vk.RequestUnmarshal("video.getAlbumsByVideo", &response, params, Params{"extended": true})
 
 	return
 }
@@ -218,8 +212,7 @@ type VideoGetCommentsResponse struct {
 //
 // https://vk.com/dev/video.getComments
 func (vk *VK) VideoGetComments(params Params) (response VideoGetCommentsResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("video.getComments", params, &response)
+	err = vk.RequestUnmarshal("video.getComments", &response, params, Params{"extended": false})
 
 	return
 }
@@ -237,8 +230,7 @@ type VideoGetCommentsExtendedResponse struct {
 //
 // https://vk.com/dev/video.getComments
 func (vk *VK) VideoGetCommentsExtended(params Params) (response VideoGetCommentsExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("video.getComments", params, &response)
+	err = vk.RequestUnmarshal("video.getComments", &response, params, Params{"extended": true})
 
 	return
 }
@@ -247,7 +239,7 @@ func (vk *VK) VideoGetCommentsExtended(params Params) (response VideoGetComments
 //
 // https://vk.com/dev/video.removeFromAlbum
 func (vk *VK) VideoRemoveFromAlbum(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.removeFromAlbum", params, &response)
+	err = vk.RequestUnmarshal("video.removeFromAlbum", &response, params)
 	return
 }
 
@@ -255,7 +247,7 @@ func (vk *VK) VideoRemoveFromAlbum(params Params) (response int, err error) {
 //
 // https://vk.com/dev/video.reorderAlbums
 func (vk *VK) VideoReorderAlbums(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.reorderAlbums", params, &response)
+	err = vk.RequestUnmarshal("video.reorderAlbums", &response, params)
 	return
 }
 
@@ -263,7 +255,7 @@ func (vk *VK) VideoReorderAlbums(params Params) (response int, err error) {
 //
 // https://vk.com/dev/video.reorderVideos
 func (vk *VK) VideoReorderVideos(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.reorderVideos", params, &response)
+	err = vk.RequestUnmarshal("video.reorderVideos", &response, params)
 	return
 }
 
@@ -271,7 +263,7 @@ func (vk *VK) VideoReorderVideos(params Params) (response int, err error) {
 //
 // https://vk.com/dev/video.report
 func (vk *VK) VideoReport(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.report", params, &response)
+	err = vk.RequestUnmarshal("video.report", &response, params)
 	return
 }
 
@@ -279,7 +271,7 @@ func (vk *VK) VideoReport(params Params) (response int, err error) {
 //
 // https://vk.com/dev/video.reportComment
 func (vk *VK) VideoReportComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.reportComment", params, &response)
+	err = vk.RequestUnmarshal("video.reportComment", &response, params)
 	return
 }
 
@@ -287,7 +279,7 @@ func (vk *VK) VideoReportComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/video.restore
 func (vk *VK) VideoRestore(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.restore", params, &response)
+	err = vk.RequestUnmarshal("video.restore", &response, params)
 	return
 }
 
@@ -295,7 +287,7 @@ func (vk *VK) VideoRestore(params Params) (response int, err error) {
 //
 // https://vk.com/dev/video.restoreComment
 func (vk *VK) VideoRestoreComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("video.restoreComment", params, &response)
+	err = vk.RequestUnmarshal("video.restoreComment", &response, params)
 	return
 }
 
@@ -306,7 +298,7 @@ type VideoSaveResponse object.VideoSaveResult
 //
 // https://vk.com/dev/video.save
 func (vk *VK) VideoSave(params Params) (response VideoSaveResponse, err error) {
-	err = vk.RequestUnmarshal("video.save", params, &response)
+	err = vk.RequestUnmarshal("video.save", &response, params)
 	return
 }
 
@@ -322,8 +314,7 @@ type VideoSearchResponse struct {
 //
 // https://vk.com/dev/video.search
 func (vk *VK) VideoSearch(params Params) (response VideoSearchResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("video.search", params, &response)
+	err = vk.RequestUnmarshal("video.search", &response, params, Params{"extended": false})
 
 	return
 }
@@ -341,8 +332,7 @@ type VideoSearchExtendedResponse struct {
 //
 // https://vk.com/dev/video.search
 func (vk *VK) VideoSearchExtended(params Params) (response VideoSearchExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("video.search", params, &response)
+	err = vk.RequestUnmarshal("video.search", &response, params, Params{"extended": true})
 
 	return
 }

--- a/api/wall.go
+++ b/api/wall.go
@@ -8,7 +8,7 @@ import (
 //
 // https://vk.com/dev/wall.closeComments
 func (vk *VK) WallCloseComments(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("wall.closeComments", params, &response)
+	err = vk.RequestUnmarshal("wall.closeComments", &response, params)
 	return
 }
 
@@ -22,7 +22,7 @@ type WallCreateCommentResponse struct {
 //
 // https://vk.com/dev/wall.createComment
 func (vk *VK) WallCreateComment(params Params) (response WallCreateCommentResponse, err error) {
-	err = vk.RequestUnmarshal("wall.createComment", params, &response)
+	err = vk.RequestUnmarshal("wall.createComment", &response, params)
 	return
 }
 
@@ -30,7 +30,7 @@ func (vk *VK) WallCreateComment(params Params) (response WallCreateCommentRespon
 //
 // https://vk.com/dev/wall.delete
 func (vk *VK) WallDelete(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("wall.delete", params, &response)
+	err = vk.RequestUnmarshal("wall.delete", &response, params)
 	return
 }
 
@@ -38,7 +38,7 @@ func (vk *VK) WallDelete(params Params) (response int, err error) {
 //
 // https://vk.com/dev/wall.deleteComment
 func (vk *VK) WallDeleteComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("wall.deleteComment", params, &response)
+	err = vk.RequestUnmarshal("wall.deleteComment", &response, params)
 	return
 }
 
@@ -51,7 +51,7 @@ type WallEditResponse struct {
 //
 // https://vk.com/dev/wall.edit
 func (vk *VK) WallEdit(params Params) (response WallEditResponse, err error) {
-	err = vk.RequestUnmarshal("wall.edit", params, &response)
+	err = vk.RequestUnmarshal("wall.edit", &response, params)
 	return
 }
 
@@ -59,7 +59,7 @@ func (vk *VK) WallEdit(params Params) (response WallEditResponse, err error) {
 //
 // https://vk.com/dev/wall.editAdsStealth
 func (vk *VK) WallEditAdsStealth(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("wall.editAdsStealth", params, &response)
+	err = vk.RequestUnmarshal("wall.editAdsStealth", &response, params)
 	return
 }
 
@@ -67,7 +67,7 @@ func (vk *VK) WallEditAdsStealth(params Params) (response int, err error) {
 //
 // https://vk.com/dev/wall.editComment
 func (vk *VK) WallEditComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("wall.editComment", params, &response)
+	err = vk.RequestUnmarshal("wall.editComment", &response, params)
 	return
 }
 
@@ -83,8 +83,7 @@ type WallGetResponse struct {
 //
 // https://vk.com/dev/wall.get
 func (vk *VK) WallGet(params Params) (response WallGetResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("wall.get", params, &response)
+	err = vk.RequestUnmarshal("wall.get", &response, params, Params{"extended": false})
 
 	return
 }
@@ -102,8 +101,7 @@ type WallGetExtendedResponse struct {
 //
 // https://vk.com/dev/wall.get
 func (vk *VK) WallGetExtended(params Params) (response WallGetExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("wall.get", params, &response)
+	err = vk.RequestUnmarshal("wall.get", &response, params, Params{"extended": true})
 
 	return
 }
@@ -117,8 +115,7 @@ type WallGetByIDResponse []object.WallWallpost
 //
 // https://vk.com/dev/wall.getById
 func (vk *VK) WallGetByID(params Params) (response WallGetByIDResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("wall.getById", params, &response)
+	err = vk.RequestUnmarshal("wall.getById", &response, params, Params{"extended": false})
 
 	return
 }
@@ -135,8 +132,7 @@ type WallGetByIDExtendedResponse struct {
 //
 // https://vk.com/dev/wall.getById
 func (vk *VK) WallGetByIDExtended(params Params) (response WallGetByIDExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("wall.getById", params, &response)
+	err = vk.RequestUnmarshal("wall.getById", &response, params, Params{"extended": true})
 
 	return
 }
@@ -156,8 +152,7 @@ type WallGetCommentResponse struct {
 //
 // https://vk.com/dev/wall.getComment
 func (vk *VK) WallGetComment(params Params) (response WallGetCommentResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("wall.getComment", params, &response)
+	err = vk.RequestUnmarshal("wall.getComment", &response, params, Params{"extended": false})
 
 	return
 }
@@ -180,8 +175,7 @@ type WallGetCommentExtendedResponse struct {
 //
 // https://vk.com/dev/wall.getComment
 func (vk *VK) WallGetCommentExtended(params Params) (response WallGetCommentExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("wall.getComment", params, &response)
+	err = vk.RequestUnmarshal("wall.getComment", &response, params, Params{"extended": true})
 
 	return
 }
@@ -202,8 +196,7 @@ type WallGetCommentsResponse struct {
 //
 // https://vk.com/dev/wall.getComments
 func (vk *VK) WallGetComments(params Params) (response WallGetCommentsResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("wall.getComments", params, &response)
+	err = vk.RequestUnmarshal("wall.getComments", &response, params, Params{"extended": false})
 
 	return
 }
@@ -225,8 +218,7 @@ type WallGetCommentsExtendedResponse struct {
 //
 // https://vk.com/dev/wall.getComments
 func (vk *VK) WallGetCommentsExtended(params Params) (response WallGetCommentsExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("wall.getComments", params, &response)
+	err = vk.RequestUnmarshal("wall.getComments", &response, params, Params{"extended": true})
 
 	return
 }
@@ -241,7 +233,7 @@ type WallGetRepostsResponse struct {
 //
 // https://vk.com/dev/wall.getReposts
 func (vk *VK) WallGetReposts(params Params) (response WallGetRepostsResponse, err error) {
-	err = vk.RequestUnmarshal("wall.getReposts", params, &response)
+	err = vk.RequestUnmarshal("wall.getReposts", &response, params)
 	return
 }
 
@@ -249,7 +241,7 @@ func (vk *VK) WallGetReposts(params Params) (response WallGetRepostsResponse, er
 //
 // https://vk.com/dev/wall.openComments
 func (vk *VK) WallOpenComments(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("wall.openComments", params, &response)
+	err = vk.RequestUnmarshal("wall.openComments", &response, params)
 	return
 }
 
@@ -257,7 +249,7 @@ func (vk *VK) WallOpenComments(params Params) (response int, err error) {
 //
 // https://vk.com/dev/wall.pin
 func (vk *VK) WallPin(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("wall.pin", params, &response)
+	err = vk.RequestUnmarshal("wall.pin", &response, params)
 	return
 }
 
@@ -270,7 +262,7 @@ type WallPostResponse struct {
 //
 // https://vk.com/dev/wall.post
 func (vk *VK) WallPost(params Params) (response WallPostResponse, err error) {
-	err = vk.RequestUnmarshal("wall.post", params, &response)
+	err = vk.RequestUnmarshal("wall.post", &response, params)
 	return
 }
 
@@ -285,7 +277,7 @@ type WallPostAdsStealthResponse struct {
 //
 // https://vk.com/dev/wall.postAdsStealth
 func (vk *VK) WallPostAdsStealth(params Params) (response WallPostAdsStealthResponse, err error) {
-	err = vk.RequestUnmarshal("wall.postAdsStealth", params, &response)
+	err = vk.RequestUnmarshal("wall.postAdsStealth", &response, params)
 	return
 }
 
@@ -293,7 +285,7 @@ func (vk *VK) WallPostAdsStealth(params Params) (response WallPostAdsStealthResp
 //
 // https://vk.com/dev/wall.reportComment
 func (vk *VK) WallReportComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("wall.reportComment", params, &response)
+	err = vk.RequestUnmarshal("wall.reportComment", &response, params)
 	return
 }
 
@@ -301,7 +293,7 @@ func (vk *VK) WallReportComment(params Params) (response int, err error) {
 //
 // https://vk.com/dev/wall.reportPost
 func (vk *VK) WallReportPost(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("wall.reportPost", params, &response)
+	err = vk.RequestUnmarshal("wall.reportPost", &response, params)
 	return
 }
 
@@ -317,7 +309,7 @@ type WallRepostResponse struct {
 //
 // https://vk.com/dev/wall.repost
 func (vk *VK) WallRepost(params Params) (response WallRepostResponse, err error) {
-	err = vk.RequestUnmarshal("wall.repost", params, &response)
+	err = vk.RequestUnmarshal("wall.repost", &response, params)
 	return
 }
 
@@ -325,7 +317,7 @@ func (vk *VK) WallRepost(params Params) (response WallRepostResponse, err error)
 //
 // https://vk.com/dev/wall.restore
 func (vk *VK) WallRestore(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("wall.restore", params, &response)
+	err = vk.RequestUnmarshal("wall.restore", &response, params)
 	return
 }
 
@@ -333,7 +325,7 @@ func (vk *VK) WallRestore(params Params) (response int, err error) {
 //
 // https://vk.com/dev/wall.restoreComment
 func (vk *VK) WallRestoreComment(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("wall.restoreComment", params, &response)
+	err = vk.RequestUnmarshal("wall.restoreComment", &response, params)
 	return
 }
 
@@ -349,8 +341,7 @@ type WallSearchResponse struct {
 //
 // https://vk.com/dev/wall.search
 func (vk *VK) WallSearch(params Params) (response WallSearchResponse, err error) {
-	params["extended"] = false
-	err = vk.RequestUnmarshal("wall.search", params, &response)
+	err = vk.RequestUnmarshal("wall.search", &response, params, Params{"extended": false})
 
 	return
 }
@@ -368,8 +359,7 @@ type WallSearchExtendedResponse struct {
 //
 // https://vk.com/dev/wall.search
 func (vk *VK) WallSearchExtended(params Params) (response WallSearchExtendedResponse, err error) {
-	params["extended"] = true
-	err = vk.RequestUnmarshal("wall.search", params, &response)
+	err = vk.RequestUnmarshal("wall.search", &response, params, Params{"extended": true})
 
 	return
 }
@@ -378,6 +368,6 @@ func (vk *VK) WallSearchExtended(params Params) (response WallSearchExtendedResp
 //
 // https://vk.com/dev/wall.unpin
 func (vk *VK) WallUnpin(params Params) (response int, err error) {
-	err = vk.RequestUnmarshal("wall.unpin", params, &response)
+	err = vk.RequestUnmarshal("wall.unpin", &response, params)
 	return
 }

--- a/api/widgets.go
+++ b/api/widgets.go
@@ -14,7 +14,7 @@ type WidgetsGetCommentsResponse struct {
 //
 // https://vk.com/dev/widgets.getComments
 func (vk *VK) WidgetsGetComments(params Params) (response WidgetsGetCommentsResponse, err error) {
-	err = vk.RequestUnmarshal("widgets.getComments", params, &response)
+	err = vk.RequestUnmarshal("widgets.getComments", &response, params)
 	return
 }
 
@@ -28,6 +28,6 @@ type WidgetsGetPagesResponse struct {
 //
 // https://vk.com/dev/widgets.getPages
 func (vk *VK) WidgetsGetPages(params Params) (response WidgetsGetPagesResponse, err error) {
-	err = vk.RequestUnmarshal("widgets.getPages", params, &response)
+	err = vk.RequestUnmarshal("widgets.getPages", &response, params)
 	return
 }

--- a/api/widgets_test.go
+++ b/api/widgets_test.go
@@ -41,7 +41,7 @@ func TestVK_WidgetsGetPages(t *testing.T) {
 
 	needServiceToken(t)
 
-	res, err := vkService.WidgetsGetPages(api.Params{})
+	res, err := vkService.WidgetsGetPages(nil)
 	noError(t, err)
 	assert.NotEmpty(t, res)
 }

--- a/longpoll-bot/longpoll.go
+++ b/longpoll-bot/longpoll.go
@@ -66,7 +66,7 @@ func NewLongpoll(vk *api.VK, groupID int) (*Longpoll, error) {
 // This means that if the http.DefaultClient is modified by other components
 // of your application the modifications will be picked up by the SDK as well.
 func NewLongpollCommunity(vk *api.VK) (*Longpoll, error) {
-	resp, err := vk.GroupsGetByID(api.Params{})
+	resp, err := vk.GroupsGetByID(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/longpoll-user/v3/wrapper_test.go
+++ b/longpoll-user/v3/wrapper_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 	vkUser.Limit = 3
 
 	if vkUser.AccessToken != "" {
-		user, err := vkUser.UsersGet(api.Params{})
+		user, err := vkUser.UsersGet(nil)
 		if err != nil {
 			log.Fatalf("USER_TOKEN bad: %v", err)
 		}

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -357,7 +357,7 @@ func (s *Streaming) Shutdown() {
 // This means that if the http.DefaultClient is modified by other components
 // of your application the modifications will be picked up by the SDK as well.
 func NewStreaming(vk *api.VK) (*Streaming, error) {
-	resp, err := vk.StreamingGetServerURL(api.Params{})
+	resp, err := vk.StreamingGetServerURL(nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
В функции `api.RequestUnmarshal`, `api.Request`, `api.Handler` теперь можно пробросить `...Params`

Преимущества:

- нет лишнего копирования мап
- некоторые методы больше не влияют на параметры
- поддержка `nil` в методах