### PR TITLE
Fix data race in Bot LongPoll.

### DIFF
--- a/longpoll-bot/longpoll.go
+++ b/longpoll-bot/longpoll.go
@@ -143,7 +143,7 @@ func (lp *LongPoll) checkResponse(response Response) (err error) {
 	return
 }
 
-func (lp LongPoll) autoSetting() error {
+func (lp *LongPoll) autoSetting() error {
 	params := api.Params{
 		"group_id":    lp.GroupID,
 		"enabled":     true,


### PR DESCRIPTION
Fixes data race in `autoSetting` method.

Write:
https://github.com/SevereCloud/vksdk/blob/fb2c46c17a63b35bbe8c5c9d890a341ac230bef5/longpoll-bot/longpoll.go#L196

Read(receiver copying):
https://github.com/SevereCloud/vksdk/blob/fb2c46c17a63b35bbe8c5c9d890a341ac230bef5/longpoll-bot/longpoll.go#L146