### PR TITLE
UploadGroupWallDoc fix

### DIFF
--- a/api/upload.go
+++ b/api/upload.go
@@ -610,12 +610,13 @@ func (vk *VK) UploadWallDoc(title, tags string, file io.Reader) (response DocsSa
 // Supported formats: any formats excepting mp3 and executable files.
 //
 // Limits: file size up to 200 MB.
-func (vk *VK) UploadGroupWallDoc(groupID int, title, tags string, file io.Reader) (
+func (vk *VK) UploadGroupWallDoc(groupID int, typeDoc, title, tags string, file io.Reader) (
 	response DocsSaveResponse,
 	err error,
 ) {
 	uploadServer, err := vk.DocsGetWallUploadServer(Params{
 		"group_id": groupID,
+		"type":     typeDoc,
 	})
 	if err != nil {
 		return

--- a/api/upload_test.go
+++ b/api/upload_test.go
@@ -372,7 +372,7 @@ func TestVK_UploadGroupWallDoc(t *testing.T) {
 	}
 	defer response.Body.Close()
 
-	_, err = vkUser.UploadGroupWallDoc(vkGroupID, "test.jpeg", "test", response.Body)
+	_, err = vkUser.UploadGroupWallDoc(vkGroupID, "doc", "test.jpeg", "test", response.Body)
 	noError(t, err)
 }
 
@@ -543,7 +543,7 @@ func TestVK_Upload_Error(t *testing.T) {
 	_, _ = vk.UploadDoc("", "", new(bytes.Buffer))
 	_, _ = vk.UploadGroupDoc(1, "", "", new(bytes.Buffer))
 	_, _ = vk.UploadWallDoc("", "", new(bytes.Buffer))
-	_, _ = vk.UploadGroupWallDoc(1, "", "", new(bytes.Buffer))
+	_, _ = vk.UploadGroupWallDoc(1, "", "", "", new(bytes.Buffer))
 	_, _ = vk.UploadMessagesDoc(1, "", "", "", new(bytes.Buffer))
 	_, _ = vk.UploadOwnerCoverPhoto(1, 0, 0, 0, 0, new(bytes.Buffer))
 	_, _ = vk.UploadStoriesPhoto(api.Params{}, new(bytes.Buffer))


### PR DESCRIPTION
Vk have undocumented feature, when you specify kind of document to upload via UploadGroupWallDoc.
It works as in UploadMessageDoc and you can't upload graffiti or voice message without this feature.
