### PR TITLE
Fixed an issue with raising wrong error in execute method

### DIFF
--- a/api/execute.go
+++ b/api/execute.go
@@ -22,6 +22,9 @@ func (vk *VK) ExecuteWithArgs(code string, params Params, obj interface{}) error
 	}
 
 	resp, err := vk.Handler("execute", params, reqParams)
+	if err != nil {
+		return err
+	}
 
 	jsonErr := json.Unmarshal(resp.Response, &obj)
 	if jsonErr != nil {


### PR DESCRIPTION
Раньше если в методе execute ВК выдавал ошибку, код её просто
проглатывал. В итоге, приходил пустой результат и ошибку выдавал уже
json.Unmarshal. Я добавил проверку, случилась ли ошибка, и если она случилась, она вернётся.