### PR TITLE
Ошибка при парсинге сообщения {failed: 1}

### DIFF
--- a/longpoll-bot/longpoll_test.go
+++ b/longpoll-bot/longpoll_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/SevereCloud/vksdk/v2/api"
 	"github.com/SevereCloud/vksdk/v2/events"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLongPoll_Shutdown(t *testing.T) {
@@ -252,7 +252,9 @@ func TestParseResponse(t *testing.T) {
 			},
 		},
 	}
+
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -261,21 +263,7 @@ func TestParseResponse(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			assertEqualResponses(t, test.expected, actual)
+			assert.Equal(t, test.expected, actual)
 		})
-	}
-}
-
-func assertEqualResponses(t *testing.T, expected, actual Response) {
-	t.Helper()
-
-	if expected.Ts != actual.Ts {
-		t.Fatalf("ts not equal, expected: '%s', actual: '%s'", expected.Ts, actual.Ts)
-	}
-	if expected.Failed != actual.Failed {
-		t.Fatalf("failed not equal, expected: '%d', actual: '%d'", expected.Failed, actual.Failed)
-	}
-	if !reflect.DeepEqual(expected.Updates, actual.Updates) {
-		t.Fatalf("updates not equal, expected: '%v', actual: '%v'", expected.Updates, actual.Updates)
 	}
 }


### PR DESCRIPTION
Привет!

При ошибке `{failed: 1}` от ВК поле "ts" приходит в формате **числа**, а не строки, как мы ожидаем. https://dev.vk.com/api/bots-long-poll/getting-started#%D0%9E%D1%88%D0%B8%D0%B1%D0%BA%D0%B8

Поэтому, при десериализации в структуру 
```go
// Response struct.
type Response struct {
	Ts      string              `json:"ts"`
	Updates []events.GroupEvent `json:"updates"`
	Failed  int                 `json:"failed"`
}
```

Происходит ошибка:
```
cannot unmarshal number into Go struct field Response.ts of type string
```

Предлагаю вариант решения почти аналогичный тому, как они делают в официальном sdk на java https://github.com/VKCOM/vk-java-sdk/blob/564a64e1c95ae44ce2df9a2c3db6c838970bbc33/sdk/src/main/java/com/vk/api/sdk/events/longpoll/LongPollQueryBuilder.java#L89