### PR TITLE
Поддержка zstd словаря

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -98,9 +98,7 @@ VK API способно возвращать ответ в виде [MessagePack
 СЛОМАННУЮ КОДИРОВКУ.
 
 Для сжатия, вместо классического gzip, можно использовать
-[zstd](https://github.com/facebook/zstd). Сейчас vksdk поддерживает zstd без
-словаря. Если кто знает как получать словарь,
-[отпишитесь сюда](https://github.com/SevereCloud/vksdk/issues/180).
+[zstd](https://github.com/facebook/zstd).
 
 ```go
 vk := api.NewVK(os.Getenv("USER_TOKEN"))
@@ -126,6 +124,18 @@ if err != nil {
 	log.Fatal(err)
 }
 log.Println("msgpack:", len(r)) // msgpack: 650775
+```
+
+Чтобы загрузить и использовать zstd словарь, воспользуйтесь
+методом `vk.UpdateZstdDict()`
+
+```go
+vk.EnableZstd()
+
+err := vk.UpdateZstdDict()
+if err != nil {
+	log.Fatal(err)
+}
 ```
 
 ### Запрос любого метода

--- a/api/account.go
+++ b/api/account.go
@@ -108,6 +108,21 @@ func (vk *VK) AccountGetPushSettings(params Params) (response AccountGetPushSett
 	return
 }
 
+// AccountGetZSTDDictResponse struct.
+type AccountGetZSTDDictResponse struct {
+	Link    string `json:"link"`
+	Version string `json:"version"`
+	Hash    string `json:"hash"`
+}
+
+// AccountGetZSTDDict method.
+//
+// https://vk.com/dev/account.getZSTDDict
+func (vk *VK) AccountGetZSTDDict(params Params) (response AccountGetZSTDDictResponse, err error) {
+	err = vk.RequestUnmarshal("account.getZSTDDict", &response, params)
+	return
+}
+
 // AccountRegisterDevice subscribes an iOS/Android/Windows/Mac based device to receive push notifications.
 //
 // https://vk.com/dev/account.registerDevice

--- a/api/account_test.go
+++ b/api/account_test.go
@@ -124,6 +124,16 @@ func TestVK_AccountGetPushSettings(t *testing.T) {
 	noError(t, err)
 }
 
+func TestVK_AccountGetZSTDDict(t *testing.T) {
+	t.Parallel()
+
+	needUserToken(t)
+
+	vkUser.EnableZstd()
+	err := vkUser.UpdateZstdDict()
+	noError(t, err)
+}
+
 // func TestVK_AccountRegisterDevice(t *testing.T) {
 // TODO: Add test cases
 // }


### PR DESCRIPTION
```go
vk.EnableZstd()

err := vk.UpdateZstdDict()
if err != nil {
	log.Fatal(err)
}
```

## Как это работает?

VK поддерживает сжатие запросов используя [zstd](https://github.com/facebook/zstd) со словарем. Для получения ссылки на словарь, вызвается метод `account.getZSTDDict`

```go
type AccountGetZSTDDictResponse struct {
	Link    string `json:"link"`
	Version string `json:"version"`
	Hash    string `json:"hash"`
}
```

Файл начинается с версии словаря:

| 00 | 01 | 02 | 03 | 04 | 05 | 06 | 07 | 08 | 09 | 0A |
|----|----|----|----|----|----|----|----|----|----|----|
| 64 | 69 | 63 | 74 | 5F | 76 | 32 | 37 | A4 | 30 | EC |
| **d**  | **i**  | **c**  | **t**  | **_**  | **v**  | **2**  | 7  | �  | 0  | �  |

Сам zstd словарь начинается с [магического номера](https://datatracker.ietf.org/doc/html/rfc8878#section-5)`0xEC30A437` в little-endian формате.

Версия словаря передается в поле `x-zstd-dict-version`

## Странности

Сейчас метод `account.getZSTDDict` не работает(по некоторым причинам). Сам метод  можно вызывать только с помощью токена пользователя.

### Словарь для json или msgpack?

![image](https://user-images.githubusercontent.com/14944123/151808992-5e4c3f3c-1b90-46aa-ac89-c58a1a85c3a6.png)

В [выступлении](https://www.youtube.com/watch?v=KDcOa_QbSQ0)([статье](https://habr.com/ru/company/vk/blog/594633/)) говорится о использовании zstd вместе с msgpack, но сам словарь(`data_v2`) **тренировался на json**, что делает его бесполезным с msgpack...

¯\_(ツ)_/¯

### Проблема загрузки словаря

В модуле [github.com/klauspost/compress/zstd](https://pkg.go.dev/github.com/klauspost/compress@v1.14.2/zstd) используется опциональная функция `zstd.WithDecoderDicts(data)`. Каждый вызов `zstd.NewReader(resp.Body, optionWithDecoderDicts)` сначала разбирает словарь, а затем добавляет его к ридеру, что может сказаться на перфомансе

---
This close #180 