### PR TITLE
Fix track_id type in marusia skill

### DIFF
--- a/marusia/skill.go
+++ b/marusia/skill.go
@@ -438,7 +438,7 @@ type AudioPlaylist struct {
 // AudioStream описание информации об аудиозаписи.
 type AudioStream struct {
 	// ID аудио внутри плейлиста, должен быть уникальным для каждого аудио.
-	TrackID string `json:"track_id"`
+	TrackID int `json:"track_id"`
 
 	// Тип источника аудиозаписи. Может иметь 2 значения url и vk.
 	// source_type url доступен только после одобрения со стороны


### PR DESCRIPTION
Fix `track_id` type to `int` according to example: https://dev.vk.com/marusia/player#player_status.
```json
{
    "client_player_status": {
        "track_id": 456239080
    }
}
```