### PR TITLE
Update board.go

### DIFF
--- a/object/board.go
+++ b/object/board.go
@@ -36,5 +36,5 @@ type BoardTopicPoll struct {
 	OwnerID  int           `json:"owner_id"`  // Poll owner's ID
 	PollID   int           `json:"poll_id"`   // Poll ID
 	Question string        `json:"question"`  // Poll question
-	Votes    string        `json:"votes"`     // Votes number
+	Votes    int           `json:"votes"`     // Votes number
 }


### PR DESCRIPTION
This should fix the error below (returned when executing `BoardGetCommentsExtended`).

```
json: cannot unmarshal number into Go struct field BoardTopicPoll.poll.votes of type string
```