### PR TITLE
fix panic while unmarshaling into `object.BaseLinkRating`

### DIFF
--- a/object/object.go
+++ b/object/object.go
@@ -285,8 +285,8 @@ type BaseLinkProduct struct {
 
 // BaseLinkRating struct.
 type BaseLinkRating struct {
-	ReviewsCount int     `json:"reviews_count"`
-	Stars        float64 `json:"stars"`
+	ReviewsCount json.Number `json:"reviews_count"`
+	Stars        float64     `json:"stars"`
 }
 
 // BasePlace struct.

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -2,6 +2,7 @@ package object_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -319,4 +320,14 @@ func TestBaseSticker_MinSizeBackground(t *testing.T) {
 	}, object.BaseImage{
 		Width: 10, Height: 20,
 	})
+}
+
+func TestBaseLinkRating_UnmarshalJSON(t *testing.T) {
+	ratingJSON := []byte(`{"reviews_count":1.0,"stars":5.0}`)
+	var rating object.BaseLinkRating
+
+	assert.NoError(t, json.Unmarshal(ratingJSON, &rating))
+	review, _ := rating.ReviewsCount.Float64()
+	assert.Equal(t, 1.0, review)
+	assert.Equal(t, 5.0, rating.Stars)
 }


### PR DESCRIPTION
Field reviews_count has incorrect data type because it float not int