### PR TITLE
feat(upload): streaming upload for files

### DIFF
--- a/api/upload.go
+++ b/api/upload.go
@@ -6,12 +6,19 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net/http"
+	"os"
 
 	"github.com/SevereCloud/vksdk/v3/object"
 )
 
 // UploadFile uploading file.
 func (vk *VK) UploadFile(url string, file io.Reader, fieldname, filename string) (bodyContent []byte, err error) {
+	if f, ok := file.(*os.File); ok {
+		bodyContent, err = vk.uploadFileWithSize(url, f, fieldname, filename)
+		return
+	}
+
 	body := new(bytes.Buffer)
 	writer := multipart.NewWriter(body)
 
@@ -35,6 +42,98 @@ func (vk *VK) UploadFile(url string, file io.Reader, fieldname, filename string)
 	defer resp.Body.Close()
 
 	bodyContent, err = io.ReadAll(resp.Body)
+
+	return
+}
+
+// uploadFileWithSize uploading file without buffering the whole multipart body in memory.
+func (vk *VK) uploadFileWithSize(url string, file *os.File, fieldname, filename string) (bodyContent []byte, err error) {
+	currentOffset, err := file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		return
+	}
+
+	fileSize := info.Size() - currentOffset
+	if fileSize < 0 {
+		fileSize = 0
+	}
+
+	contentType, contentLength, boundary, err := multipartEnvelope(fieldname, filename, fileSize)
+	if err != nil {
+		return
+	}
+
+	reader, writer := io.Pipe()
+
+	req, err := http.NewRequest(http.MethodPost, url, reader)
+	if err != nil {
+		_ = reader.Close()
+		_ = writer.Close()
+		return
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.ContentLength = contentLength
+
+	go func() {
+		multipartWriter := multipart.NewWriter(writer)
+		if err := multipartWriter.SetBoundary(boundary); err != nil {
+			_ = writer.CloseWithError(err)
+			return
+		}
+
+		part, err := multipartWriter.CreateFormFile(fieldname, filename)
+		if err != nil {
+			_ = writer.CloseWithError(err)
+			return
+		}
+
+		if _, err = io.Copy(part, file); err != nil {
+			_ = writer.CloseWithError(err)
+			return
+		}
+
+		if err = multipartWriter.Close(); err != nil {
+			_ = writer.CloseWithError(err)
+			return
+		}
+
+		_ = writer.Close()
+	}()
+
+	resp, err := vk.Client.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	bodyContent, err = io.ReadAll(resp.Body)
+
+	return
+}
+
+// multipartEnvelope returns multipart content metadata for file upload.
+func multipartEnvelope(fieldname, filename string, fileSize int64) (contentType string, contentLength int64, boundary string, err error) {
+	header := new(bytes.Buffer)
+	writer := multipart.NewWriter(header)
+	boundary = writer.Boundary()
+
+	_, err = writer.CreateFormFile(fieldname, filename)
+	if err != nil {
+		return
+	}
+
+	contentType = writer.FormDataContentType()
+	err = writer.Close()
+	if err != nil {
+		return
+	}
+
+	contentLength = int64(header.Len()) + fileSize
 
 	return
 }

--- a/api/upload.go
+++ b/api/upload.go
@@ -23,12 +23,12 @@ func (vk *VK) UploadFile(url string, file io.Reader, fieldname, filename string)
 
 	part, err := writer.CreateFormFile(fieldname, filename)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("api: %w", err)
 	}
 
 	_, err = io.Copy(part, file)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("api: %w", err)
 	}
 
 	contentType := writer.FormDataContentType()
@@ -36,25 +36,28 @@ func (vk *VK) UploadFile(url string, file io.Reader, fieldname, filename string)
 
 	resp, err := vk.Client.Post(url, contentType, body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("api: %w", err)
 	}
 	defer resp.Body.Close()
 
 	bodyContent, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("api: %w", err)
+	}
 
-	return bodyContent, err
+	return bodyContent, nil
 }
 
 // uploadFileWithSize uploading file without buffering the whole multipart body in memory.
 func (vk *VK) uploadFileWithSize(url string, file *os.File, fieldname, filename string) (bodyContent []byte, err error) {
 	currentOffset, err := file.Seek(0, io.SeekCurrent)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("api: %w", err)
 	}
 
 	info, err := file.Stat()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("api: %w", err)
 	}
 
 	fileSize := max(info.Size()-currentOffset, 0)
@@ -70,7 +73,8 @@ func (vk *VK) uploadFileWithSize(url string, file *os.File, fieldname, filename 
 	if err != nil {
 		_ = reader.Close()
 		_ = writer.Close()
-		return nil, err
+
+		return nil, fmt.Errorf("api: %w", err)
 	}
 
 	req.Header.Set("Content-Type", contentType)
@@ -78,6 +82,7 @@ func (vk *VK) uploadFileWithSize(url string, file *os.File, fieldname, filename 
 
 	go func() {
 		multipartWriter := multipart.NewWriter(writer)
+
 		pipeErr := multipartWriter.SetBoundary(boundary)
 		if pipeErr != nil {
 			_ = writer.CloseWithError(pipeErr)
@@ -107,13 +112,16 @@ func (vk *VK) uploadFileWithSize(url string, file *os.File, fieldname, filename 
 
 	resp, err := vk.Client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("api: %w", err)
 	}
 	defer resp.Body.Close()
 
 	bodyContent, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("api: %w", err)
+	}
 
-	return bodyContent, err
+	return bodyContent, nil
 }
 
 // multipartEnvelope returns multipart content metadata for file upload.

--- a/api/upload.go
+++ b/api/upload.go
@@ -15,8 +15,7 @@ import (
 // UploadFile uploading file.
 func (vk *VK) UploadFile(url string, file io.Reader, fieldname, filename string) (bodyContent []byte, err error) {
 	if f, ok := file.(*os.File); ok {
-		bodyContent, err = vk.uploadFileWithSize(url, f, fieldname, filename)
-		return
+		return vk.uploadFileWithSize(url, f, fieldname, filename)
 	}
 
 	body := new(bytes.Buffer)
@@ -24,12 +23,12 @@ func (vk *VK) UploadFile(url string, file io.Reader, fieldname, filename string)
 
 	part, err := writer.CreateFormFile(fieldname, filename)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	_, err = io.Copy(part, file)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	contentType := writer.FormDataContentType()
@@ -37,35 +36,32 @@ func (vk *VK) UploadFile(url string, file io.Reader, fieldname, filename string)
 
 	resp, err := vk.Client.Post(url, contentType, body)
 	if err != nil {
-		return
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	bodyContent, err = io.ReadAll(resp.Body)
 
-	return
+	return bodyContent, err
 }
 
 // uploadFileWithSize uploading file without buffering the whole multipart body in memory.
 func (vk *VK) uploadFileWithSize(url string, file *os.File, fieldname, filename string) (bodyContent []byte, err error) {
 	currentOffset, err := file.Seek(0, io.SeekCurrent)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	info, err := file.Stat()
 	if err != nil {
-		return
+		return nil, err
 	}
 
-	fileSize := info.Size() - currentOffset
-	if fileSize < 0 {
-		fileSize = 0
-	}
+	fileSize := max(info.Size()-currentOffset, 0)
 
 	contentType, contentLength, boundary, err := multipartEnvelope(fieldname, filename, fileSize)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	reader, writer := io.Pipe()
@@ -74,31 +70,35 @@ func (vk *VK) uploadFileWithSize(url string, file *os.File, fieldname, filename 
 	if err != nil {
 		_ = reader.Close()
 		_ = writer.Close()
-		return
+		return nil, err
 	}
+
 	req.Header.Set("Content-Type", contentType)
 	req.ContentLength = contentLength
 
 	go func() {
 		multipartWriter := multipart.NewWriter(writer)
-		if err := multipartWriter.SetBoundary(boundary); err != nil {
-			_ = writer.CloseWithError(err)
+		pipeErr := multipartWriter.SetBoundary(boundary)
+		if pipeErr != nil {
+			_ = writer.CloseWithError(pipeErr)
 			return
 		}
 
-		part, err := multipartWriter.CreateFormFile(fieldname, filename)
-		if err != nil {
-			_ = writer.CloseWithError(err)
+		part, pipeErr := multipartWriter.CreateFormFile(fieldname, filename)
+		if pipeErr != nil {
+			_ = writer.CloseWithError(pipeErr)
 			return
 		}
 
-		if _, err = io.Copy(part, file); err != nil {
-			_ = writer.CloseWithError(err)
+		_, pipeErr = io.Copy(part, file)
+		if pipeErr != nil {
+			_ = writer.CloseWithError(pipeErr)
 			return
 		}
 
-		if err = multipartWriter.Close(); err != nil {
-			_ = writer.CloseWithError(err)
+		pipeErr = multipartWriter.Close()
+		if pipeErr != nil {
+			_ = writer.CloseWithError(pipeErr)
 			return
 		}
 
@@ -107,13 +107,13 @@ func (vk *VK) uploadFileWithSize(url string, file *os.File, fieldname, filename 
 
 	resp, err := vk.Client.Do(req)
 	if err != nil {
-		return
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	bodyContent, err = io.ReadAll(resp.Body)
 
-	return
+	return bodyContent, err
 }
 
 // multipartEnvelope returns multipart content metadata for file upload.
@@ -128,6 +128,7 @@ func multipartEnvelope(fieldname, filename string, fileSize int64) (contentType 
 	}
 
 	contentType = writer.FormDataContentType()
+
 	err = writer.Close()
 	if err != nil {
 		return

--- a/api/upload_test.go
+++ b/api/upload_test.go
@@ -3,7 +3,12 @@ package api_test
 import (
 	"bytes"
 	"io"
+	"mime"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/SevereCloud/vksdk/v3/api"
@@ -30,6 +35,88 @@ func TestVK_UploadFile(t *testing.T) {
 	}
 
 	f("", new(bytes.Buffer), "", "", true)
+}
+
+func TestVK_UploadFile_StreamHeadersMatchBuffered(t *testing.T) {
+	t.Parallel()
+
+	vk := api.NewVK("")
+	const fileContent = "same content"
+
+	tempDir := t.TempDir()
+	fileName := filepath.Join(tempDir, "payload.txt")
+	err := os.WriteFile(fileName, []byte(fileContent), 0o600)
+	if err != nil {
+		t.Fatalf("os.WriteFile() err = %v", err)
+	}
+
+	type uploadRequest struct {
+		header        http.Header
+		contentLength int64
+	}
+
+	requests := make([]uploadRequest, 0, 2)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, uploadRequest{
+			header:        r.Header.Clone(),
+			contentLength: r.ContentLength,
+		})
+
+		reader, err := r.MultipartReader()
+		if err != nil {
+			t.Fatalf("r.MultipartReader() err = %v", err)
+		}
+
+		part, err := reader.NextPart()
+		if err != nil {
+			t.Fatalf("reader.NextPart() err = %v", err)
+		}
+
+		body, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("io.ReadAll() err = %v", err)
+		}
+
+		assert.Equal(t, fileContent, string(body))
+
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	defer server.Close()
+
+	_, err = vk.UploadFile(server.URL, strings.NewReader(fileContent), "photo", "photo.jpeg")
+	if err != nil {
+		t.Fatalf("VK.UploadFile() err = %v", err)
+	}
+
+	file, err := os.Open(fileName)
+	if err != nil {
+		t.Fatalf("os.Open() err = %v", err)
+	}
+	defer file.Close()
+
+	_, err = vk.UploadFile(server.URL, file, "photo", "photo.jpeg")
+	if err != nil {
+		t.Fatalf("VK.UploadFile() err = %v", err)
+	}
+
+	if len(requests) != 2 {
+		t.Fatalf("len(requests) = %d, want 2", len(requests))
+	}
+
+	bufferedType, _, err := mime.ParseMediaType(requests[0].header.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("mime.ParseMediaType() err = %v", err)
+	}
+
+	streamingType, _, err := mime.ParseMediaType(requests[1].header.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("mime.ParseMediaType() err = %v", err)
+	}
+
+	assert.Equal(t, bufferedType, streamingType)
+	assert.Equal(t, "multipart/form-data", streamingType)
+	assert.Equal(t, requests[0].contentLength, requests[1].contentLength)
 }
 
 func TestVK_UploadPhoto(t *testing.T) {

--- a/api/upload_test.go
+++ b/api/upload_test.go
@@ -41,10 +41,12 @@ func TestVK_UploadFile_StreamHeadersMatchBuffered(t *testing.T) {
 	t.Parallel()
 
 	vk := api.NewVK("")
+
 	const fileContent = "same content"
 
 	tempDir := t.TempDir()
 	fileName := filepath.Join(tempDir, "payload.txt")
+
 	err := os.WriteFile(fileName, []byte(fileContent), 0o600)
 	if err != nil {
 		t.Fatalf("os.WriteFile() err = %v", err)


### PR DESCRIPTION
Problem: file uploads currently build the entire multipart/form-data body in memory, so memory usage grows with file size.

Without introducing a breaking change, only the internal implementation of the existing upload flow could be changed. Since most upload methods already go through UploadFile, the optimization could be added there without changing the public API.

What was done: UploadFile now uses streaming multipart uploads via io.Pipe when the provided reader is an *os.File, with a precomputed Content-Length. For all other io.Reader implementations, the existing buffered behavior is preserved. Public APIs remain unchanged.

Closes https://github.com/SevereCloud/vksdk/issues/329