### PR TITLE
Add EventMessageReaction for message reactions

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -74,6 +74,7 @@ const (
 	EventDonutSubscriptionPriceChanged = "donut_subscription_price_changed"
 	EventDonutMoneyWithdraw            = "donut_money_withdraw"
 	EventDonutMoneyWithdrawError       = "donut_money_withdraw_error"
+	EventMessageReaction               = "message_reaction_event"
 )
 
 // GroupEvent struct.
@@ -95,6 +96,7 @@ type FuncList struct {
 	messageDeny                   []func(context.Context, MessageDenyObject)
 	messageTypingState            []func(context.Context, MessageTypingStateObject)
 	messageEvent                  []func(context.Context, MessageEventObject)
+	messageReaction               []func(context.Context, MessageReactionObject)
 	photoNew                      []func(context.Context, PhotoNewObject)
 	photoCommentNew               []func(context.Context, PhotoCommentNewObject)
 	photoCommentEdit              []func(context.Context, PhotoCommentEditObject)
@@ -1212,6 +1214,25 @@ func (fl *FuncList) Handler(ctx context.Context, e GroupEvent) error { //nolint:
 		}
 
 		for _, f := range fl.donutMoneyWithdrawError {
+			if fl.goroutine {
+				go func() { f(context.WithoutCancel(ctx), obj) }()
+			} else {
+				f(ctx, obj)
+			}
+		}
+	case EventMessageReaction:
+		if len(fl.messageReaction) == 0 {
+			break
+		}
+
+		var obj MessageReactionObject
+
+		err := json.Unmarshal(e.Object, &obj)
+		if err != nil {
+			return fmt.Errorf("events: %w", err)
+		}
+
+		for _, f := range fl.messageReaction {
 			if fl.goroutine {
 				go func() { f(context.WithoutCancel(ctx), obj) }()
 			} else {

--- a/events/objects.go
+++ b/events/objects.go
@@ -357,3 +357,11 @@ type DonutMoneyWithdrawObject struct {
 type DonutMoneyWithdrawErrorObject struct {
 	Reason string `json:"reason"`
 }
+
+// MessageReactionObject struct.
+type MessageReactionObject struct {
+	ReactedID  int `json:"reacted_id"`
+	PeerID     int `json:"peer_id"`
+	CmID       int `json:"cmid"`
+	ReactionID int `json:"reaction_id"`
+}


### PR DESCRIPTION
Added new event `EventMessageReaction` (`message_reaction_event`) to handle message reactions (likes, hearts, etc.) in real-time for bots.
Added EventMessageReaction event with MessageReactionObject struct to handle message reactions (likes, hearts, etc.).

## Changes
- Added `EventMessageReaction` constant to events list
- Added `MessageReactionObject` struct with fields:
  - `ReactedID` - user who reacted
  - `PeerID` - chat ID
  - `CmID` - conversation message ID
  - `ReactionID` - reaction type ID (1=❤️, 4=👍, etc.)
- Added event processing in `Handler`
- Added handler registration method

Usage:

lp.OnEvent(events.EventMessageReaction, func(ctx context.Context, ev events.GroupEvent) {
...
})